### PR TITLE
📝 AGENTS.mdとdocs/を追加しREADMEを拡充

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# AGENTS.md
+
+イナバくん（稲葉勇人）のポートフォリオサイト。AI エージェント向けの構成メモ。
+
+## 技術スタック
+
+| 種別           | 内容                                   |
+| -------------- | -------------------------------------- |
+| フレームワーク | Next.js 14 (Pages Router)              |
+| 言語           | TypeScript 5.4 (`strict: true`)        |
+| UI             | Chakra UI v2 + Emotion                 |
+| アニメーション | Framer Motion, react-animated-cursor   |
+| Lint/Format    | ESLint (eslint-config-next) + Prettier |
+| CI             | GitHub Actions                         |
+
+App Router ではなく **Pages Router** を使っている。`src/pages/` にファイルを置くとルーティングされる。
+
+## ディレクトリ構成
+
+```
+src/
+├── pages/                      # ルーティング（Pages Router）
+│   ├── _app.jsx                # 全ページ共通のProvider。※ここだけ .jsx
+│   ├── index.tsx               # トップ（/）
+│   ├── 404.tsx                 # 404ページ
+│   ├── profile/index.tsx       # /profile
+│   └── contact/index.tsx       # /contact
+├── components/
+│   ├── common/                 # 全ページで使う共通コンポーネント
+│   │   ├── PageTemplate/       # 全ページのレイアウト土台（後述）
+│   │   ├── HeaderNavigation/   # ヘッダー + SPのドロワーメニュー
+│   │   └── SnsList/            # 右下に固定表示するSNSアイコン
+│   └── pages/                  # 特定ページ専用のコンポーネント
+│       ├── top/Fv/             # トップのファーストビュー
+│       └── profile/            # ProfileHead, TextListArea
+├── lib/
+│   ├── colors.ts               # 配色定数 COLORS
+│   └── chakraTheme.ts          # Chakra のテーマ（フォント指定のみ）
+└── styles/global.css           # グローバルCSS（::selection のみ）
+
+public/                         # 画像・favicon・Search Console 認証ファイル
+.github/
+├── workflows/ci.yml            # CI
+├── composite_actions/client-setup/  # CI 共通のセットアップ処理
+└── dependabot.yml              # npm を月次で更新
+```
+
+コンポーネントは `ComponentName/ComponentName.tsx` の1ディレクトリ1コンポーネント形式。default export。
+
+## 主要な設計
+
+### PageTemplate がすべての起点
+
+`src/components/common/PageTemplate/PageTemplate.tsx` が全ページのレイアウトを担っている。新しいページを足すときは必ずこれで包む。
+
+```tsx
+<PageTemplate pageTitle="Profile">{/* ページ本体 */}</PageTemplate>
+```
+
+`PageTemplate` の責務:
+
+- `<Head>` … `{pageTitle} | Have Your Inabakun` のタイトル、description、OGP、Google Fonts (Playfair Display) の読み込み
+- 背景（`public/site_bg.svg` を `position: fixed` + グレースケール）
+- `HeaderNavigation` と `SnsList` の描画
+- Framer Motion によるページ遷移のフェード
+
+`pageTitle` は任意。省略するとタイトルは `Have Your Inabakun` のみになる（トップページがこれ）。
+
+### スタイリングの決めごと
+
+- CSS ファイルは書かず、Chakra UI の props でスタイルを当てる
+- 色は直書きせず `src/lib/colors.ts` の `COLORS` を使う
+- レスポンシブは Chakra のブレークポイントオブジェクト記法で書く。SP ファーストで `{ base: "...", md: "..." }` が基本形
+- テキストの半透明表現は `rgba(255,255,255, 0.5)` が各所で直書きされている（`COLORS` 化されていない既知の不統一）
+
+### `_app.jsx` の注意点
+
+- このファイルだけ TypeScript ではなく **`.jsx`**。`AppProps` の型付けがコメントアウトされたまま残っている
+- `react-animated-cursor` は `next/dynamic` の `ssr: false` で読み込む必要がある（SSR で落ちるため）
+- ページ遷移アニメーションのため `AnimatePresence mode="wait"` で `<Component>` を包んでいる
+
+## コマンド
+
+```bash
+npm run dev           # 開発サーバー (http://localhost:3000)
+npm run build         # プロダクションビルド
+npm run start         # ビルド結果の起動
+
+npm run tsc           # 型チェック
+npm run lint:check    # Lint（CI と同じ）
+npm run lint          # Lint + 自動修正
+npm run format:check  # Prettier チェック（CI と同じ）
+npm run format        # Prettier で整形
+```
+
+## CI
+
+`.github/workflows/ci.yml`。main への push と main 向け PR で走る。
+
+`type-check` / `lint-check` / `format-check` の3つが並列で回り、すべて通ったら `build-app` が実行される。ローカルでは以下を通してからコミットすれば CI と同じ検証になる。
+
+```bash
+npm run tsc && npm run lint:check && npm run format:check && npm run build
+```
+
+Node のバージョンは CI 側で 21 固定（`.github/composite_actions/client-setup/action.yml`）。
+
+## 変更時に気をつけること
+
+- **プロフィールの内容は本人の実データ**。`src/pages/profile/index.tsx` の職歴・スキル、`ProfileHead.tsx` の氏名・生年月日は勝手に書き換えない
+- `public/google40ef8dfd6cf9110c.html` は Google Search Console の所有権確認ファイル。消さない
+- OGP 画像の URL が `https://www.inabakun.com/ogp.jpg` と絶対パスで直書きされている
+- import は全て相対パス（`../../../lib/colors` など）。`tsconfig.json` に `@/*` のエイリアス設定はあるが未使用
+
+## 既知のTODO
+
+コード中に `TODO:` コメントが点在している（トップの実績リスト、ロゴ、components 配下のディレクトリ構造見直し、import のエイリアス化など）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,117 +1,28 @@
 # AGENTS.md
 
-イナバくん（稲葉勇人）のポートフォリオサイト。AI エージェント向けの構成メモ。
+イナバくん（稲葉勇人）のポートフォリオサイト。Next.js 14 (Pages Router) + TypeScript + Chakra UI 製。
+ページは `/`（トップ）・`/profile`・`/contact` の3枚と 404 のみの小さなサイト。
 
-## 技術スタック
+## 開発フロー（必読）
 
-| 種別           | 内容                                   |
-| -------------- | -------------------------------------- |
-| フレームワーク | Next.js 14 (Pages Router)              |
-| 言語           | TypeScript 5.4 (`strict: true`)        |
-| UI             | Chakra UI v2 + Emotion                 |
-| アニメーション | Framer Motion, react-animated-cursor   |
-| Lint/Format    | ESLint (eslint-config-next) + Prettier |
-| CI             | GitHub Actions                         |
+**main に直接コミット・push しない。** ファイルを変更する作業は必ずブランチを切り、
+draft PR を作ってから始める。コミットメッセージは日本語で、冒頭に絵文字を付ける。
 
-App Router ではなく **Pages Router** を使っている。`src/pages/` にファイルを置くとルーティングされる。
+手順の詳細は `.claude/skills/pr-workflow/SKILL.md` に置いてある。変更作業に入る前に
+`pr-workflow` スキルを読むこと。
 
-## ディレクトリ構成
+## ドキュメント
 
-```
-src/
-├── pages/                      # ルーティング（Pages Router）
-│   ├── _app.jsx                # 全ページ共通のProvider。※ここだけ .jsx
-│   ├── index.tsx               # トップ（/）
-│   ├── 404.tsx                 # 404ページ
-│   ├── profile/index.tsx       # /profile
-│   └── contact/index.tsx       # /contact
-├── components/
-│   ├── common/                 # 全ページで使う共通コンポーネント
-│   │   ├── PageTemplate/       # 全ページのレイアウト土台（後述）
-│   │   ├── HeaderNavigation/   # ヘッダー + SPのドロワーメニュー
-│   │   └── SnsList/            # 右下に固定表示するSNSアイコン
-│   └── pages/                  # 特定ページ専用のコンポーネント
-│       ├── top/Fv/             # トップのファーストビュー
-│       └── profile/            # ProfileHead, TextListArea
-├── lib/
-│   ├── colors.ts               # 配色定数 COLORS
-│   └── chakraTheme.ts          # Chakra のテーマ（フォント指定のみ）
-└── styles/global.css           # グローバルCSS（::selection のみ）
+| ドキュメント                            | 内容                                                                                         |
+| --------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [構成](docs/architecture.md)            | 技術スタック、ディレクトリ構成、PageTemplate を起点としたレイアウト設計、`_app.jsx` の注意点 |
+| [コーディング規約](docs/conventions.md) | コンポーネントの置き方、スタイリング、変更時に触ってはいけないもの                           |
+| [開発](docs/development.md)             | セットアップ、npm スクリプト、CI、デプロイ                                                   |
 
-public/                         # 画像・favicon・Search Console 認証ファイル
-.github/
-├── workflows/ci.yml            # CI
-├── composite_actions/client-setup/  # CI 共通のセットアップ処理
-└── dependabot.yml              # npm を月次で更新
-```
+## 最低限おさえること
 
-コンポーネントは `ComponentName/ComponentName.tsx` の1ディレクトリ1コンポーネント形式。default export。
-
-## 主要な設計
-
-### PageTemplate がすべての起点
-
-`src/components/common/PageTemplate/PageTemplate.tsx` が全ページのレイアウトを担っている。新しいページを足すときは必ずこれで包む。
-
-```tsx
-<PageTemplate pageTitle="Profile">{/* ページ本体 */}</PageTemplate>
-```
-
-`PageTemplate` の責務:
-
-- `<Head>` … `{pageTitle} | Have Your Inabakun` のタイトル、description、OGP、Google Fonts (Playfair Display) の読み込み
-- 背景（`public/site_bg.svg` を `position: fixed` + グレースケール）
-- `HeaderNavigation` と `SnsList` の描画
-- Framer Motion によるページ遷移のフェード
-
-`pageTitle` は任意。省略するとタイトルは `Have Your Inabakun` のみになる（トップページがこれ）。
-
-### スタイリングの決めごと
-
-- CSS ファイルは書かず、Chakra UI の props でスタイルを当てる
-- 色は直書きせず `src/lib/colors.ts` の `COLORS` を使う
-- レスポンシブは Chakra のブレークポイントオブジェクト記法で書く。SP ファーストで `{ base: "...", md: "..." }` が基本形
-- テキストの半透明表現は `rgba(255,255,255, 0.5)` が各所で直書きされている（`COLORS` 化されていない既知の不統一）
-
-### `_app.jsx` の注意点
-
-- このファイルだけ TypeScript ではなく **`.jsx`**。`AppProps` の型付けがコメントアウトされたまま残っている
-- `react-animated-cursor` は `next/dynamic` の `ssr: false` で読み込む必要がある（SSR で落ちるため）
-- ページ遷移アニメーションのため `AnimatePresence mode="wait"` で `<Component>` を包んでいる
-
-## コマンド
-
-```bash
-npm run dev           # 開発サーバー (http://localhost:3000)
-npm run build         # プロダクションビルド
-npm run start         # ビルド結果の起動
-
-npm run tsc           # 型チェック
-npm run lint:check    # Lint（CI と同じ）
-npm run lint          # Lint + 自動修正
-npm run format:check  # Prettier チェック（CI と同じ）
-npm run format        # Prettier で整形
-```
-
-## CI
-
-`.github/workflows/ci.yml`。main への push と main 向け PR で走る。
-
-`type-check` / `lint-check` / `format-check` の3つが並列で回り、すべて通ったら `build-app` が実行される。ローカルでは以下を通してからコミットすれば CI と同じ検証になる。
-
-```bash
-npm run tsc && npm run lint:check && npm run format:check && npm run build
-```
-
-Node のバージョンは CI 側で 21 固定（`.github/composite_actions/client-setup/action.yml`）。
-
-## 変更時に気をつけること
-
-- **プロフィールの内容は本人の実データ**。`src/pages/profile/index.tsx` の職歴・スキル、`ProfileHead.tsx` の氏名・生年月日は勝手に書き換えない
-- `public/google40ef8dfd6cf9110c.html` は Google Search Console の所有権確認ファイル。消さない
-- OGP 画像の URL が `https://www.inabakun.com/ogp.jpg` と絶対パスで直書きされている
-- import は全て相対パス（`../../../lib/colors` など）。`tsconfig.json` に `@/*` のエイリアス設定はあるが未使用
-
-## 既知のTODO
-
-コード中に `TODO:` コメントが点在している（トップの実績リスト、ロゴ、components 配下のディレクトリ構造見直し、import のエイリアス化など）。
+- App Router ではなく **Pages Router**。`src/pages/` にファイルを置くとルーティングされる
+- 全ページを `src/components/common/PageTemplate/PageTemplate.tsx` で包む。`<Head>`・背景・ヘッダー・ページ遷移アニメーションはこれが持っている
+- CSS ファイルは書かず Chakra UI の props でスタイルを当てる。色は `src/lib/colors.ts` の `COLORS` から取る
+- push する前に `npm run tsc && npm run lint:check && npm run format:check && npm run build`
+- プロフィールの職歴・氏名などは本人の実データなので勝手に書き換えない

--- a/README.md
+++ b/README.md
@@ -1,5 +1,69 @@
-## Have Your Inabakun?
+# Have Your Inabakun?
 
-イナバくんのポートフォリオサイト
+イナバくん（稲葉勇人 / Hayato Inaba）のポートフォリオサイトです。
 
-[https://www.inabakun.com/](https://www.inabakun.com/)
+🔗 [https://www.inabakun.com/](https://www.inabakun.com/)
+
+## 技術スタック
+
+- [Next.js 14](https://nextjs.org/) (Pages Router)
+- [TypeScript](https://www.typescriptlang.org/)
+- [Chakra UI](https://chakra-ui.com/) v2 / [Emotion](https://emotion.sh/)
+- [Framer Motion](https://www.framer.com/motion/) — ページ遷移アニメーション
+- [react-animated-cursor](https://github.com/stephenscaff/react-animated-cursor) — カスタムカーソル
+- ESLint / Prettier / GitHub Actions
+
+## セットアップ
+
+```bash
+npm install
+npm run dev
+```
+
+[http://localhost:3000](http://localhost:3000) で開きます。
+
+> Node.js は CI と揃えて 21 以上を推奨。
+
+## コマンド
+
+| コマンド               | 内容                            |
+| ---------------------- | ------------------------------- |
+| `npm run dev`          | 開発サーバーを起動              |
+| `npm run build`        | プロダクションビルド            |
+| `npm run start`        | ビルド結果を起動                |
+| `npm run tsc`          | 型チェック                      |
+| `npm run lint:check`   | Lint（修正なし）                |
+| `npm run lint`         | Lint + 自動修正                 |
+| `npm run format:check` | Prettier のフォーマットチェック |
+| `npm run format`       | Prettier で整形                 |
+
+## ページ構成
+
+| パス       | 内容                                       |
+| ---------- | ------------------------------------------ |
+| `/`        | トップ（ファーストビュー）                 |
+| `/profile` | プロフィール、スキル、経歴                 |
+| `/contact` | お問い合わせ（現在は Twitter DM への案内） |
+
+## ディレクトリ構成
+
+```
+src/
+├── pages/        # ルーティング（Pages Router）
+├── components/
+│   ├── common/   # 全ページ共通のコンポーネント
+│   └── pages/    # 各ページ専用のコンポーネント
+├── lib/          # 配色定数、Chakra のテーマ
+└── styles/       # グローバルCSS
+public/           # 画像・favicon など静的ファイル
+```
+
+詳しい構成や開発ルールは [AGENTS.md](AGENTS.md) を参照してください。
+
+## CI
+
+main への push / PR で GitHub Actions が走ります（型チェック・Lint・フォーマットチェックが通ったらビルド）。ローカルでは以下で同じ内容を確認できます。
+
+```bash
+npm run tsc && npm run lint:check && npm run format:check && npm run build
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,68 @@
+# 構成
+
+## 技術スタック
+
+| 種別           | 内容                                   |
+| -------------- | -------------------------------------- |
+| フレームワーク | Next.js 14 (Pages Router)              |
+| 言語           | TypeScript 5.4 (`strict: true`)        |
+| UI             | Chakra UI v2 + Emotion                 |
+| アニメーション | Framer Motion, react-animated-cursor   |
+| Lint/Format    | ESLint (eslint-config-next) + Prettier |
+| CI             | GitHub Actions                         |
+| デプロイ       | Vercel                                 |
+
+App Router ではなく **Pages Router** を使っている。`src/pages/` にファイルを置くとルーティングされる。
+
+## ディレクトリ構成
+
+```
+src/
+├── pages/                      # ルーティング（Pages Router）
+│   ├── _app.jsx                # 全ページ共通のProvider。※ここだけ .jsx
+│   ├── index.tsx               # トップ（/）
+│   ├── 404.tsx                 # 404ページ
+│   ├── profile/index.tsx       # /profile
+│   └── contact/index.tsx       # /contact
+├── components/
+│   ├── common/                 # 全ページで使う共通コンポーネント
+│   │   ├── PageTemplate/       # 全ページのレイアウト土台（後述）
+│   │   ├── HeaderNavigation/   # ヘッダー + SPのドロワーメニュー
+│   │   └── SnsList/            # 右下に固定表示するSNSアイコン
+│   └── pages/                  # 特定ページ専用のコンポーネント
+│       ├── top/Fv/             # トップのファーストビュー
+│       └── profile/            # ProfileHead, TextListArea
+├── lib/
+│   ├── colors.ts               # 配色定数 COLORS
+│   └── chakraTheme.ts          # Chakra のテーマ（フォント指定のみ）
+└── styles/global.css           # グローバルCSS（::selection のみ）
+
+public/                         # 画像・favicon・Search Console 認証ファイル
+.github/
+├── workflows/ci.yml            # CI
+├── composite_actions/client-setup/  # CI 共通のセットアップ処理
+└── dependabot.yml              # npm を月次で更新
+```
+
+## PageTemplate がすべての起点
+
+`src/components/common/PageTemplate/PageTemplate.tsx` が全ページのレイアウトを担っている。新しいページを足すときは必ずこれで包む。
+
+```tsx
+<PageTemplate pageTitle="Profile">{/* ページ本体 */}</PageTemplate>
+```
+
+`PageTemplate` の責務:
+
+- `<Head>` … `{pageTitle} | Have Your Inabakun` のタイトル、description、OGP、Google Fonts (Playfair Display) の読み込み
+- 背景（`public/site_bg.svg` を `position: fixed` + グレースケール）
+- `HeaderNavigation` と `SnsList` の描画
+- Framer Motion によるページ遷移のフェード
+
+`pageTitle` は任意。省略するとタイトルは `Have Your Inabakun` のみになる（トップページがこれ）。
+
+## `_app.jsx` の注意点
+
+- このファイルだけ TypeScript ではなく **`.jsx`**。`AppProps` の型付けがコメントアウトされたまま残っている
+- `react-animated-cursor` は `next/dynamic` の `ssr: false` で読み込む必要がある（SSR で落ちるため）
+- ページ遷移アニメーションのため `AnimatePresence mode="wait"` で `<Component>` を包んでいる

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,28 @@
+# コーディング規約
+
+## コンポーネントの置き方
+
+`ComponentName/ComponentName.tsx` の1ディレクトリ1コンポーネント形式。default export。
+
+全ページで使うものは `src/components/common/`、特定ページ専用のものは `src/components/pages/<ページ名>/` に置く。
+
+## スタイリング
+
+- CSS ファイルは書かず、Chakra UI の props でスタイルを当てる
+- 色は直書きせず `src/lib/colors.ts` の `COLORS` を使う
+- レスポンシブは Chakra のブレークポイントオブジェクト記法で書く。SP ファーストで `{ base: "...", md: "..." }` が基本形
+- テキストの半透明表現は `rgba(255,255,255, 0.5)` が各所で直書きされている（`COLORS` 化されていない既知の不統一）
+
+## import
+
+全て相対パス（`../../../lib/colors` など）。`tsconfig.json` に `@/*` のエイリアス設定はあるが未使用。
+
+## 変更時に気をつけること
+
+- **プロフィールの内容は本人の実データ**。`src/pages/profile/index.tsx` の職歴・スキル、`ProfileHead.tsx` の氏名・生年月日は勝手に書き換えない
+- `public/google40ef8dfd6cf9110c.html` は Google Search Console の所有権確認ファイル。消さない
+- OGP 画像の URL が `https://www.inabakun.com/ogp.jpg` と絶対パスで直書きされている
+
+## 既知のTODO
+
+コード中に `TODO:` コメントが点在している（トップの実績リスト、ロゴ、components 配下のディレクトリ構造見直し、import のエイリアス化など）。

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,44 @@
+# 開発
+
+## セットアップ
+
+```bash
+npm install
+npm run dev
+```
+
+[http://localhost:3000](http://localhost:3000) で開く。Node.js は CI と揃えて 21 以上を推奨。
+
+## コマンド
+
+```bash
+npm run dev           # 開発サーバー (http://localhost:3000)
+npm run build         # プロダクションビルド
+npm run start         # ビルド結果の起動
+
+npm run tsc           # 型チェック
+npm run lint:check    # Lint（CI と同じ）
+npm run lint          # Lint + 自動修正
+npm run format:check  # Prettier チェック（CI と同じ）
+npm run format        # Prettier で整形
+```
+
+Prettier の対象は `**/*.{js,jsx,ts,tsx,json,css}`。Markdown は対象外なので、ドキュメントを整形しても CI では検査されない。
+
+## CI
+
+`.github/workflows/ci.yml`。main への push と main 向け PR で走る。
+
+`type-check` / `lint-check` / `format-check` の3つが並列で回り、すべて通ったら `build-app` が実行される。push する前に以下を通せば CI と同じ検証になる。
+
+```bash
+npm run tsc && npm run lint:check && npm run format:check && npm run build
+```
+
+format で落ちたら `npm run format`、lint で落ちたら `npm run lint` で自動修正できる。
+
+Node のバージョンは CI 側で 21 固定（`.github/composite_actions/client-setup/action.yml`）。`node_modules` は `package-lock.json` のハッシュをキーにキャッシュされる。
+
+## デプロイ
+
+Vercel。PR を作ると Preview デプロイが走る。


### PR DESCRIPTION
## 概要

README が3行しかなく、初見でプロジェクトの構成や開発手順が分からない状態だったためドキュメントを整備した。AGENTS.md は目次＋概要のみに絞り、詳細は `docs/` 配下に分離している。

## 変更内容

### `AGENTS.md`（新規）

概要・開発フロー・各ドキュメントへの目次・「最低限おさえること」だけの短いファイル。詳細は持たせず `docs/` へ誘導する。

### `docs/`（新規）

| ファイル | 内容 |
| --- | --- |
| `docs/architecture.md` | 技術スタック、ディレクトリ構成、PageTemplate を起点としたレイアウト設計、`_app.jsx` の注意点 |
| `docs/conventions.md` | コンポーネントの置き方、スタイリング規約、変更時に触ってはいけないもの |
| `docs/development.md` | セットアップ、npm スクリプト、CI、デプロイ |

内容として押さえたのは以下:

- App Router ではなく Pages Router であること
- `PageTemplate` が全ページの `<Head>`・背景・ヘッダー・ページ遷移アニメーションを持つ起点であること
- CSS ファイルを書かず Chakra props でスタイルを当て、色は `src/lib/colors.ts` の `COLORS` から取る規約
- `_app.jsx` だけ `.jsx` である点、`react-animated-cursor` を `ssr: false` で動的 import する必要がある点
- プロフィールは本人の実データなので勝手に書き換えない、Search Console の所有権確認ファイルを消さない

### `README.md`（更新）

セットアップ手順、npm スクリプト一覧、ページ構成、ディレクトリ概要、CI を追記。詳細は AGENTS.md に誘導する構成。

## 確認方法

GitHub 上で AGENTS.md → docs/ 配下へのリンクがたどれることを確認してください。

## レビュー時に見てほしいところ

- **AGENTS.md の「開発フロー（必読）」が `.claude/skills/pr-workflow/SKILL.md` を参照していますが、その実体は #189 にあります。** このブランチ単体ではリンク先が存在しないので、#189 を先にマージするのが自然です。
- ドキュメントのみの変更で、アプリケーションコードには一切手を入れていません。
- **CI は赤ですが、この PR が原因ではありません**（下記）。

## CI について

Type Check / Lint Check / Format Check の3つとも、チェック本体に到達する前の `npm install` で落ちています。

```
npm ERR! ERESOLVE could not resolve
While resolving: @typescript-eslint/eslint-plugin@8.0.0
Found: @typescript-eslint/parser@5.62.0
```

`@typescript-eslint/eslint-plugin` が v8 で `parser` が `^5.62.0` のままのため peer dependency が解決できません。main の最新コミットでも同じ失敗が出ている既存の破損で、本 PR は Markdown しか触っていないため無関係です。別 PR で `@typescript-eslint/parser` を v8 に上げるのが良さそうです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)