### PR TITLE
🔧 Vercelのデプロイ失敗を修正（pnpm-workspace.yamlにpackagesを追加）

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# シングルパッケージ構成だがビルドスクリプトの許可設定のためにこのファイルが必要。
+# pnpm 9 系はこのファイルがあると packages を必須にするため（Vercel のビルドは
+# lockfile のバージョンから pnpm 9 を選ぶ）、ルート自身を明示しておく。
+packages:
+  - "."
+
 # next の画像最適化に使う sharp と、eslint-import-resolver-typescript が使う
 # unrs-resolver はネイティブバイナリのビルドが必要なので明示的に許可する
 allowBuilds:


### PR DESCRIPTION
## 概要

Vercel のデプロイが `pnpm install` の `ERROR packages field missing or empty` で全て失敗している。
pnpm-workspace.yaml に `packages` を追加して直す。

## 背景

Vercel のビルドログ（`dpl_By6xfbsBbdFaGUz7zTbkUDsM9Ehu`）:

```
Detected `pnpm-lock.yaml` 9 which may be generated by pnpm@9.x or pnpm@10.x
Using pnpm@9.x based on project creation date
Installing dependencies...
 ERROR  packages field missing or empty
Error: Command "pnpm install" exited with 1
```

Vercel は `packageManager: pnpm@11.17.0` を見ておらず（corepack を有効にしないと参照されない）、
lockfile のバージョンとプロジェクト作成日から pnpm 9 を選んでいる。
pnpm 9 は pnpm-workspace.yaml があるとワークスペースルートとみなし `packages` を必須にするが、
#190 で追加したこのファイルには `allowBuilds` しか書いていなかった。

## 変更内容

- pnpm-workspace.yaml に `packages: ["."]` を追加

`allowBuilds` は pnpm 11 の機能なので pnpm 9 では無視されるが、
pnpm 9 はビルドスクリプトをデフォルトで実行するため sharp / unrs-resolver のビルドは走る。

## 確認方法

ローカルで Vercel と同じ pnpm 9 を使って再現・修正を確認した。

```bash
# 修正前: ERROR packages field missing or empty
# 修正後: Done in 19.3s using pnpm v9.15.9（sharp の install も完了）
npx pnpm@9.15.9 install --frozen-lockfile
```

pnpm 11（ローカル / CI）でも従来どおり通ることを確認済み。

```bash
pnpm install --frozen-lockfile && pnpm run tsc && pnpm run lint:check && pnpm run format:check && pnpm run build
```

この PR の Vercel プレビューデプロイが成功すれば修正できている。

## 残課題（この PR では対応しない）

- Vercel の Project Settings の Node.js Version が `18.x`（廃止済み）のまま。
  現状は package.json の `engines.node: ">=20.9.0"` のおかげで 24.x が使われているが、
  ダッシュボードで 24.x に直しておかないと engines を消した瞬間にまたデプロイが落ちる。
