### PR TITLE
✨ FVをWebGLパーティクルアニメーションでリニューアル

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "framer-motion": "^12.42.2",
     "next": "16.2.11",
+    "ogl": "^1.0.11",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       next:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.7(supports-color@7.2.0))(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      ogl:
+        specifier: ^1.0.11
+        version: 1.0.11
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1709,6 +1712,9 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  ogl@1.0.11:
+    resolution: {integrity: sha512-kUpC154AFfxi16pmZUK4jk3J+8zxwTWGPo03EoYA8QPbzikHoaC82n6pNTbd+oEaJonaE8aPWBlX7ad9zrqLsA==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3823,6 +3829,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
+
+  ogl@1.0.11: {}
 
   optionator@0.9.4:
     dependencies:

--- a/src/components/common/PageTemplate/PageTemplate.tsx
+++ b/src/components/common/PageTemplate/PageTemplate.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import Head from "next/head";
 import HeaderNavigation from "../HeaderNavigation/HeaderNavigation";
 import SnsList from "../SnsList/SnsList";
+import ParticleBackdrop from "../ParticleBackdrop/ParticleBackdrop";
 import { motion } from "framer-motion";
 
 type PageTemplateProps = {
@@ -33,9 +34,10 @@ const PageTemplate = (props: PageTemplateProps) => {
       </Head>
       {/*
        * before: は背景（public/site_bg.svg）をグレースケールで画面に固定するもの。
-       * 中身より先に描かれるので、後ろに続く要素がその上に乗る。
+       * その上に同じ写真からサンプリングしたパーティクルを ParticleBackdrop で重ねる。
        */}
-      <div className="bg-background-main relative mx-auto min-h-screen w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-screen before:w-screen before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:grayscale before:content-[''] md:px-[50px]">
+      <div className="bg-background-main relative mx-auto min-h-screen w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-screen before:w-screen before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:opacity-60 before:grayscale before:content-[''] md:px-[50px]">
+        <ParticleBackdrop />
         <HeaderNavigation />
         <SnsList />
 

--- a/src/components/common/ParticleBackdrop/ParticleBackdrop.tsx
+++ b/src/components/common/ParticleBackdrop/ParticleBackdrop.tsx
@@ -4,7 +4,7 @@ import { loadImage, sampleImageParticles } from "../../../lib/particleSampler";
 import { fragment, vertex } from "./shaders";
 
 const FADE_IN_DURATION = 2.2; // 秒
-const AMBIENT_COUNT = 4200; // 画面全体に散らす粒子数
+const AMBIENT_COUNT = 6500; // 画面全体に散らす粒子数
 
 /**
  * 背景画像(site_bg.svg)をパーティクルの浮遊メッシュとして描画する

--- a/src/components/common/ParticleBackdrop/ParticleBackdrop.tsx
+++ b/src/components/common/ParticleBackdrop/ParticleBackdrop.tsx
@@ -1,18 +1,16 @@
 import { useEffect, useRef } from "react";
 import { Geometry, Mesh, Program, Renderer } from "ogl";
-import {
-  loadImage,
-  sampleImageParticles,
-} from "../../../../lib/particleSampler";
+import { loadImage, sampleImageParticles } from "../../../lib/particleSampler";
 import { fragment, vertex } from "./shaders";
 
-// ロゴ("Have Your Inabakun")の実寸(px)。この単位でパーティクルの目標座標を組み立てる。
-const LOGO_WIDTH = 943;
-const LOGO_HEIGHT = 471;
+const FADE_IN_DURATION = 2.2; // 秒
+const AMBIENT_COUNT = 4200; // 画面全体に散らす粒子数
 
-const CONVERGE_DURATION = 1.6; // 秒
-
-const ParticlePortrait = () => {
+/**
+ * 背景画像(site_bg.svg)をパーティクルの浮遊メッシュとして描画する
+ * 画面全体固定のWebGL背景。マウス位置に応じて視差で揺らめく。
+ */
+const ParticleBackdrop = () => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -24,6 +22,8 @@ const ParticlePortrait = () => {
     let program: Program | null = null;
     let mesh: Mesh | null = null;
     let startTime = 0;
+    let imageWidth = 1;
+    let imageHeight = 1;
 
     const renderer = new Renderer({
       alpha: true,
@@ -51,66 +51,72 @@ const ParticlePortrait = () => {
     resize();
     window.addEventListener("resize", resize);
 
-    const mouse = { x: -9999, y: -9999 };
-    const targetMouse = { x: -9999, y: -9999 };
+    const parallax = { x: 0, y: 0 };
+    const targetParallax = { x: 0, y: 0 };
 
     const handlePointerMove = (event: PointerEvent) => {
-      const rect = container.getBoundingClientRect();
-      targetMouse.x = (event.clientX - rect.left) * renderer.dpr;
-      targetMouse.y = (event.clientY - rect.top) * renderer.dpr;
+      targetParallax.x = (event.clientX / window.innerWidth) * 2 - 1;
+      targetParallax.y = (event.clientY / window.innerHeight) * 2 - 1;
     };
-    const handlePointerLeave = () => {
-      targetMouse.x = -9999;
-      targetMouse.y = -9999;
-    };
-    container.addEventListener("pointermove", handlePointerMove);
-    container.addEventListener("pointerleave", handlePointerLeave);
+    window.addEventListener("pointermove", handlePointerMove);
 
     const init = async () => {
-      const logoImage = await loadImage("/fv_title.svg");
+      const image = await loadImage("/site_bg.svg");
       if (destroyed) return;
 
-      const logoSample = sampleImageParticles(logoImage, {
-        targetWidth: 640,
-        maxPoints: 4200,
-        mode: "alpha",
-        threshold: 40,
+      imageWidth = image.width;
+      imageHeight = image.height;
+
+      const sample = sampleImageParticles(image, {
+        targetWidth: 260,
+        maxPoints: 11000,
+        mode: "luminance-bright",
+        threshold: 26,
       });
 
-      const total = logoSample.points.length;
-      const targets = new Float32Array(total * 2);
-      const starts = new Float32Array(total * 2);
+      // 被写体の輪郭に沿う粒子 + 画面全体に散らす粒子(常に揺らめく)
+      const total = sample.points.length + AMBIENT_COUNT;
+      const positions = new Float32Array(total * 2);
+      const depths = new Float32Array(total);
       const randoms = new Float32Array(total * 2);
       const brightness = new Float32Array(total);
-      const gradient = new Float32Array(total);
+      const shape = new Float32Array(total);
 
-      logoSample.points.forEach((point, index) => {
-        const vx = (point.x / logoSample.width) * LOGO_WIDTH - LOGO_WIDTH / 2;
-        const vy =
-          (point.y / logoSample.height) * LOGO_HEIGHT - LOGO_HEIGHT / 2;
+      sample.points.forEach((point, index) => {
+        const vx = (point.x / sample.width) * imageWidth - imageWidth / 2;
+        const vy = (point.y / sample.height) * imageHeight - imageHeight / 2;
 
         const i2 = index * 2;
-        targets[i2] = vx;
-        targets[i2 + 1] = vy;
-
-        const angle = Math.random() * Math.PI * 2;
-        const radius = 260 + Math.random() * 480;
-        starts[i2] = Math.cos(angle) * radius;
-        starts[i2 + 1] = Math.sin(angle) * radius - 40;
+        positions[i2] = vx;
+        positions[i2 + 1] = vy;
 
         randoms[i2] = Math.random();
         randoms[i2 + 1] = Math.random();
+        depths[index] = Math.random();
         brightness[index] = point.brightness;
-        // 上端(オレンジ)から下端(レッド)へのグラデーション位置
-        gradient[index] = vy / LOGO_HEIGHT + 0.5;
+        shape[index] = 1;
       });
 
+      // 画面全体(cover領域より少し広め)にランダムに散らばる粒子
+      for (let i = 0; i < AMBIENT_COUNT; i++) {
+        const index = sample.points.length + i;
+        const i2 = index * 2;
+        positions[i2] = (Math.random() - 0.5) * imageWidth * 1.2;
+        positions[i2 + 1] = (Math.random() - 0.5) * imageHeight * 1.2;
+
+        randoms[i2] = Math.random();
+        randoms[i2 + 1] = Math.random();
+        depths[index] = Math.random();
+        brightness[index] = 0.15 + Math.random() * 0.35;
+        shape[index] = 0;
+      }
+
       const geometry = new Geometry(gl, {
-        aTarget: { size: 2, data: targets },
-        aStart: { size: 2, data: starts },
+        aPosition: { size: 2, data: positions },
+        aDepth: { size: 1, data: depths },
         aRandom: { size: 2, data: randoms },
         aBrightness: { size: 1, data: brightness },
-        aGradient: { size: 1, data: gradient },
+        aShape: { size: 1, data: shape },
       });
 
       program = new Program(gl, {
@@ -123,8 +129,8 @@ const ParticlePortrait = () => {
           uScale: { value: 1 },
           uTime: { value: 0 },
           uProgress: { value: 0 },
-          uMouse: { value: [-9999, -9999] },
-          uPointSize: { value: 3.2 },
+          uParallax: { value: [0, 0] },
+          uPointSize: { value: 2.2 },
           uDpr: { value: renderer.dpr },
         },
       });
@@ -138,20 +144,21 @@ const ParticlePortrait = () => {
       raf = requestAnimationFrame(tick);
       if (!program || !mesh || !startTime) return;
 
-      mouse.x += (targetMouse.x - mouse.x) * 0.18;
-      mouse.y += (targetMouse.y - mouse.y) * 0.18;
+      parallax.x += (targetParallax.x - parallax.x) * 0.05;
+      parallax.y += (targetParallax.y - parallax.y) * 0.05;
 
       const elapsed = (now - startTime) / 1000;
-      const progress = Math.min(1, elapsed / CONVERGE_DURATION);
-      // ロゴはできるだけ原寸に近いサイズで、コンテナいっぱいに収める
-      const scale =
-        Math.min(gl.canvas.width / LOGO_WIDTH, gl.canvas.height / LOGO_HEIGHT) *
-        0.92;
+      const progress = Math.min(1, elapsed / FADE_IN_DURATION);
+      // 画面全体を覆うcover相当のスケール
+      const scale = Math.max(
+        gl.canvas.width / imageWidth,
+        gl.canvas.height / imageHeight,
+      );
 
       program.uniforms.uTime.value = elapsed;
       program.uniforms.uProgress.value = progress;
       program.uniforms.uScale.value = scale;
-      program.uniforms.uMouse.value = [mouse.x, mouse.y];
+      program.uniforms.uParallax.value = [parallax.x, parallax.y];
 
       renderer.render({ scene: mesh });
     };
@@ -162,8 +169,7 @@ const ParticlePortrait = () => {
       destroyed = true;
       cancelAnimationFrame(raf);
       window.removeEventListener("resize", resize);
-      container.removeEventListener("pointermove", handlePointerMove);
-      container.removeEventListener("pointerleave", handlePointerLeave);
+      window.removeEventListener("pointermove", handlePointerMove);
       if (gl.canvas.parentElement === container) {
         container.removeChild(gl.canvas);
       }
@@ -174,11 +180,10 @@ const ParticlePortrait = () => {
   return (
     <div
       ref={containerRef}
-      role="img"
-      aria-label="Have Your Inabakun"
-      className="h-[70vh] w-full md:h-[80vh]"
+      aria-hidden
+      className="pointer-events-none fixed top-0 left-0 h-screen w-screen"
     />
   );
 };
 
-export default ParticlePortrait;
+export default ParticleBackdrop;

--- a/src/components/common/ParticleBackdrop/shaders.ts
+++ b/src/components/common/ParticleBackdrop/shaders.ts
@@ -1,0 +1,72 @@
+export const vertex = /* glsl */ `
+  attribute vec2 aPosition;
+  attribute float aDepth;
+  attribute vec2 aRandom;
+  attribute float aBrightness;
+  attribute float aShape;
+
+  uniform vec2 uResolution;
+  uniform float uScale;
+  uniform float uTime;
+  uniform float uProgress;
+  uniform vec2 uParallax;
+  uniform float uPointSize;
+  uniform float uDpr;
+
+  varying float vBrightness;
+  varying float vAlpha;
+  varying float vShape;
+
+  void main() {
+    vec2 base = aPosition * uScale;
+
+    // 奥行きに応じて視差の強さを変える(近いほど大きく動く)
+    float parallaxStrength = mix(10.0, 60.0, aDepth) * uDpr;
+    vec2 offset = uParallax * parallaxStrength;
+
+    // 常時ゆっくり漂う
+    float driftX = sin(uTime * 0.22 + aRandom.x * 6.2831853) * mix(4.0, 14.0, aDepth);
+    float driftY = cos(uTime * 0.18 + aRandom.y * 6.2831853) * mix(4.0, 14.0, aDepth);
+
+    vec2 screenPos = base + uResolution * 0.5 + offset + vec2(driftX, driftY);
+
+    vec2 clip = (screenPos / uResolution) * 2.0 - 1.0;
+    clip.y = -clip.y;
+
+    // 明滅(twinkle)
+    float twinkle = 0.65 + 0.35 * sin(uTime * (0.8 + aRandom.x * 1.4) + aRandom.y * 6.2831853);
+
+    // 被写体の輪郭に沿う粒子は、周辺に散らす粒子より大きく・くっきり見せる
+    float sizeBoost = mix(1.0, 2.2, aShape);
+
+    gl_Position = vec4(clip, 0.0, 1.0);
+    gl_PointSize = uPointSize * uDpr * mix(0.6, 1.6, aDepth) * uProgress * twinkle * sizeBoost;
+
+    vBrightness = aBrightness * twinkle;
+    vAlpha = uProgress;
+    vShape = aShape;
+  }
+`;
+
+export const fragment = /* glsl */ `
+  precision highp float;
+
+  varying float vBrightness;
+  varying float vAlpha;
+  varying float vShape;
+
+  void main() {
+    vec2 uv = gl_PointCoord - 0.5;
+    float d = length(uv);
+    if (d > 0.5) discard;
+
+    float alphaBase = mix(0.25, 0.55, vShape) + vBrightness * mix(0.55, 0.9, vShape);
+    float alpha = smoothstep(0.5, 0.0, d) * alphaBase * vAlpha;
+
+    vec3 dust = vec3(1.0, 1.0, 1.0);
+    vec3 accent = vec3(0.949, 0.451, 0.078); // #f27314 (FVのグラデーションと揃える)
+    vec3 color = mix(dust, accent, vShape * 0.8);
+
+    gl_FragColor = vec4(color, alpha);
+  }
+`;

--- a/src/components/common/ParticleBackdrop/shaders.ts
+++ b/src/components/common/ParticleBackdrop/shaders.ts
@@ -38,9 +38,12 @@ export const vertex = /* glsl */ `
 
     // 被写体の輪郭に沿う粒子は、周辺に散らす粒子より大きく・くっきり見せる
     float sizeBoost = mix(1.0, 2.2, aShape);
+    // 粒子ごとの大小のばらつき(小さい粒が多く、たまに大きい粒が混ざる)
+    float sizeVariance = pow(fract(aRandom.x * 37.13 + aRandom.y * 91.7), 2.0);
+    float sizeRange = mix(0.35, 3.2, sizeVariance);
 
     gl_Position = vec4(clip, 0.0, 1.0);
-    gl_PointSize = uPointSize * uDpr * mix(0.6, 1.6, aDepth) * uProgress * twinkle * sizeBoost;
+    gl_PointSize = uPointSize * uDpr * mix(0.5, 1.4, aDepth) * sizeRange * uProgress * twinkle * sizeBoost;
 
     vBrightness = aBrightness * twinkle;
     vAlpha = uProgress;

--- a/src/components/pages/top/Fv/Fv.tsx
+++ b/src/components/pages/top/Fv/Fv.tsx
@@ -1,10 +1,10 @@
 // TODO: components 配下のディレクトリ構造を変えたい
+import ParticlePortrait from "./ParticlePortrait";
+
 const Fv = () => {
   return (
     <div className="flex min-h-[calc(100vh_-_50px)] items-center justify-center mix-blend-difference md:min-h-[calc(100vh_-_100px)]">
-      {/* svg をそのまま出したいので next/image は使わない */}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src="/fv_title.svg" alt="Have Your Inabakun" />
+      <ParticlePortrait />
     </div>
   );
 };

--- a/src/components/pages/top/Fv/ParticlePortrait.tsx
+++ b/src/components/pages/top/Fv/ParticlePortrait.tsx
@@ -71,10 +71,10 @@ const ParticlePortrait = () => {
       if (destroyed) return;
 
       const logoSample = sampleImageParticles(logoImage, {
-        targetWidth: 640,
-        maxPoints: 4200,
+        targetWidth: 760,
+        maxPoints: 6500,
         mode: "alpha",
-        threshold: 40,
+        threshold: 20,
       });
 
       const total = logoSample.points.length;
@@ -124,7 +124,7 @@ const ParticlePortrait = () => {
           uTime: { value: 0 },
           uProgress: { value: 0 },
           uMouse: { value: [-9999, -9999] },
-          uPointSize: { value: 3.2 },
+          uPointSize: { value: 4.6 },
           uDpr: { value: renderer.dpr },
         },
       });

--- a/src/components/pages/top/Fv/ParticlePortrait.tsx
+++ b/src/components/pages/top/Fv/ParticlePortrait.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef } from "react";
+import { Geometry, Mesh, Program, Renderer } from "ogl";
+import { loadImage, sampleImageParticles } from "./particleSampler";
+import { fragment, vertex } from "./shaders";
+
+// 実寸(px)ベースの仮想座標系。顔写真の下にロゴを配置した構図をこの単位で組み立てる。
+const PORTRAIT_WIDTH = 405;
+const PORTRAIT_HEIGHT = 519;
+const LOGO_WIDTH = 943;
+const LOGO_HEIGHT = 471;
+const GAP = 70;
+const VIRTUAL_WIDTH = LOGO_WIDTH;
+const VIRTUAL_HEIGHT = PORTRAIT_HEIGHT + GAP + LOGO_HEIGHT;
+
+const CONVERGE_DURATION = 1.6; // 秒
+
+const ParticlePortrait = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let raf = 0;
+    let destroyed = false;
+    let program: Program | null = null;
+    let mesh: Mesh | null = null;
+    let startTime = 0;
+
+    const renderer = new Renderer({
+      alpha: true,
+      antialias: true,
+      dpr: Math.min(window.devicePixelRatio || 1, 2),
+    });
+    const gl = renderer.gl;
+    gl.clearColor(0, 0, 0, 0);
+    gl.canvas.style.width = "100%";
+    gl.canvas.style.height = "100%";
+    gl.canvas.style.display = "block";
+    container.appendChild(gl.canvas);
+
+    const resize = () => {
+      const { clientWidth, clientHeight } = container;
+      if (clientWidth === 0 || clientHeight === 0) return;
+      renderer.setSize(clientWidth, clientHeight);
+      if (program) {
+        program.uniforms.uResolution.value = [
+          gl.canvas.width,
+          gl.canvas.height,
+        ];
+      }
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    const mouse = { x: -9999, y: -9999 };
+    const targetMouse = { x: -9999, y: -9999 };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const rect = container.getBoundingClientRect();
+      targetMouse.x = (event.clientX - rect.left) * renderer.dpr;
+      targetMouse.y = (event.clientY - rect.top) * renderer.dpr;
+    };
+    const handlePointerLeave = () => {
+      targetMouse.x = -9999;
+      targetMouse.y = -9999;
+    };
+    container.addEventListener("pointermove", handlePointerMove);
+    container.addEventListener("pointerleave", handlePointerLeave);
+
+    const init = async () => {
+      const [portraitImage, logoImage] = await Promise.all([
+        loadImage("/inabakun.png"),
+        loadImage("/fv_title.svg"),
+      ]);
+      if (destroyed) return;
+
+      const portraitSample = sampleImageParticles(portraitImage, {
+        targetWidth: 170,
+        maxPoints: 5200,
+        mode: "luminance",
+        threshold: 246,
+      });
+      const logoSample = sampleImageParticles(logoImage, {
+        targetWidth: 460,
+        maxPoints: 2600,
+        mode: "alpha",
+        threshold: 40,
+      });
+
+      const total = portraitSample.points.length + logoSample.points.length;
+      const targets = new Float32Array(total * 2);
+      const starts = new Float32Array(total * 2);
+      const randoms = new Float32Array(total * 2);
+      const brightness = new Float32Array(total);
+      const tint = new Float32Array(total);
+
+      let cursor = 0;
+      const pushPoint = (
+        vx: number,
+        vy: number,
+        pointBrightness: number,
+        pointTint: number,
+      ) => {
+        const i2 = cursor * 2;
+        targets[i2] = vx;
+        targets[i2 + 1] = vy;
+
+        const angle = Math.random() * Math.PI * 2;
+        const radius = 260 + Math.random() * 480;
+        starts[i2] = Math.cos(angle) * radius;
+        starts[i2 + 1] = Math.sin(angle) * radius - 40;
+
+        randoms[i2] = Math.random();
+        randoms[i2 + 1] = Math.random();
+        brightness[cursor] = pointBrightness;
+        tint[cursor] = pointTint;
+        cursor += 1;
+      };
+
+      portraitSample.points.forEach((point) => {
+        const vx =
+          (point.x / portraitSample.width) * PORTRAIT_WIDTH -
+          PORTRAIT_WIDTH / 2;
+        const vy =
+          (point.y / portraitSample.height) * PORTRAIT_HEIGHT -
+          VIRTUAL_HEIGHT / 2;
+        pushPoint(vx, vy, point.brightness, 0);
+      });
+
+      logoSample.points.forEach((point) => {
+        const vx = (point.x / logoSample.width) * LOGO_WIDTH - LOGO_WIDTH / 2;
+        const vy =
+          PORTRAIT_HEIGHT +
+          GAP +
+          (point.y / logoSample.height) * LOGO_HEIGHT -
+          VIRTUAL_HEIGHT / 2;
+        pushPoint(vx, vy, point.brightness, 1);
+      });
+
+      const geometry = new Geometry(gl, {
+        aTarget: { size: 2, data: targets },
+        aStart: { size: 2, data: starts },
+        aRandom: { size: 2, data: randoms },
+        aBrightness: { size: 1, data: brightness },
+        aTint: { size: 1, data: tint },
+      });
+
+      program = new Program(gl, {
+        vertex,
+        fragment,
+        transparent: true,
+        depthTest: false,
+        uniforms: {
+          uResolution: { value: [gl.canvas.width, gl.canvas.height] },
+          uScale: { value: 1 },
+          uTime: { value: 0 },
+          uProgress: { value: 0 },
+          uMouse: { value: [-9999, -9999] },
+          uPointSize: { value: 2.6 },
+          uDpr: { value: renderer.dpr },
+        },
+      });
+
+      mesh = new Mesh(gl, { mode: gl.POINTS, geometry, program });
+      resize();
+      startTime = performance.now();
+    };
+
+    const tick = (now: number) => {
+      raf = requestAnimationFrame(tick);
+      if (!program || !mesh || !startTime) return;
+
+      mouse.x += (targetMouse.x - mouse.x) * 0.18;
+      mouse.y += (targetMouse.y - mouse.y) * 0.18;
+
+      const elapsed = (now - startTime) / 1000;
+      const progress = Math.min(1, elapsed / CONVERGE_DURATION);
+      const scale =
+        Math.min(
+          gl.canvas.width / VIRTUAL_WIDTH,
+          gl.canvas.height / VIRTUAL_HEIGHT,
+        ) * 0.74;
+
+      program.uniforms.uTime.value = elapsed;
+      program.uniforms.uProgress.value = progress;
+      program.uniforms.uScale.value = scale;
+      program.uniforms.uMouse.value = [mouse.x, mouse.y];
+
+      renderer.render({ scene: mesh });
+    };
+    raf = requestAnimationFrame(tick);
+    void init();
+
+    return () => {
+      destroyed = true;
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", resize);
+      container.removeEventListener("pointermove", handlePointerMove);
+      container.removeEventListener("pointerleave", handlePointerLeave);
+      if (gl.canvas.parentElement === container) {
+        container.removeChild(gl.canvas);
+      }
+      gl.getExtension("WEBGL_lose_context")?.loseContext();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      role="img"
+      aria-label="Have Your Inabakun"
+      className="h-[70vh] w-full max-w-[600px] md:h-[80vh]"
+    />
+  );
+};
+
+export default ParticlePortrait;

--- a/src/components/pages/top/Fv/particleSampler.ts
+++ b/src/components/pages/top/Fv/particleSampler.ts
@@ -1,0 +1,86 @@
+export type ParticlePoint = {
+  x: number;
+  y: number;
+  brightness: number;
+};
+
+type SampleMode = "luminance" | "alpha";
+
+type SampleOptions = {
+  /** サンプリング用に画像を描画するオフスクリーンcanvasの幅(px) */
+  targetWidth: number;
+  /** 間引き後に残す最大点数 */
+  maxPoints: number;
+  mode: SampleMode;
+  /**
+   * luminance モード: これより暗い(背景でない)ピクセルを採用する閾値(0-255)
+   * alpha モード: これより不透明なピクセルを採用する閾値(0-255)
+   */
+  threshold: number;
+};
+
+export type SampleResult = {
+  points: ParticlePoint[];
+  width: number;
+  height: number;
+};
+
+export const loadImage = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () =>
+      reject(new Error(`画像の読み込みに失敗しました: ${src}`));
+    image.src = src;
+  });
+
+/**
+ * 画像をオフスクリーンcanvasに描画し、ピクセルを間引きながら
+ * パーティクルの元になる座標と明るさをサンプリングする。
+ */
+export const sampleImageParticles = (
+  image: HTMLImageElement,
+  { targetWidth, maxPoints, mode, threshold }: SampleOptions,
+): SampleResult => {
+  const width = targetWidth;
+  const height = Math.round(targetWidth * (image.height / image.width));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return { points: [], width, height };
+
+  ctx.drawImage(image, 0, 0, width, height);
+  const { data } = ctx.getImageData(0, 0, width, height);
+
+  const candidates: ParticlePoint[] = [];
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      const a = data[i + 3];
+
+      if (mode === "alpha") {
+        if (a > threshold) {
+          candidates.push({ x, y, brightness: a / 255 });
+        }
+        continue;
+      }
+
+      const luminance = r * 0.299 + g * 0.587 + b * 0.114;
+      if (a > 128 && luminance < threshold) {
+        // 暗いピクセルほど黒背景の上で目立つよう明るさを反転させる
+        const brightness = Math.min(1, Math.max(0.25, 1 - luminance / 255));
+        candidates.push({ x, y, brightness });
+      }
+    }
+  }
+
+  const step = Math.max(1, Math.ceil(candidates.length / maxPoints));
+  const points = candidates.filter((_, index) => index % step === 0);
+
+  return { points, width, height };
+};

--- a/src/components/pages/top/Fv/shaders.ts
+++ b/src/components/pages/top/Fv/shaders.ts
@@ -3,7 +3,7 @@ export const vertex = /* glsl */ `
   attribute vec2 aStart;
   attribute vec2 aRandom;
   attribute float aBrightness;
-  attribute float aTint;
+  attribute float aGradient;
 
   uniform vec2 uResolution;
   uniform float uScale;
@@ -14,7 +14,7 @@ export const vertex = /* glsl */ `
   uniform float uDpr;
 
   varying float vBrightness;
-  varying float vTint;
+  varying float vGradient;
   varying float vEased;
 
   void main() {
@@ -49,7 +49,7 @@ export const vertex = /* glsl */ `
     gl_PointSize = uPointSize * uDpr * (0.6 + aBrightness * 0.9) * mix(0.35, 1.0, eased);
 
     vBrightness = aBrightness;
-    vTint = aTint;
+    vGradient = aGradient;
     vEased = eased;
   }
 `;
@@ -58,7 +58,7 @@ export const fragment = /* glsl */ `
   precision highp float;
 
   varying float vBrightness;
-  varying float vTint;
+  varying float vGradient;
   varying float vEased;
 
   void main() {
@@ -68,9 +68,10 @@ export const fragment = /* glsl */ `
 
     float alpha = smoothstep(0.5, 0.0, d) * (0.3 + vBrightness * 0.7) * vEased;
 
-    vec3 white = vec3(1.0, 1.0, 1.0);
-    vec3 orange = vec3(0.8902, 0.3451, 0.0); // #e35800
-    vec3 color = mix(white, orange, vTint);
+    // 上から下にオレンジ→レッドのグラデーション
+    vec3 orange = vec3(0.949, 0.451, 0.078); // #f27314
+    vec3 red = vec3(0.784, 0.098, 0.078); // #c81914
+    vec3 color = mix(orange, red, vGradient);
 
     gl_FragColor = vec4(color, alpha);
   }

--- a/src/components/pages/top/Fv/shaders.ts
+++ b/src/components/pages/top/Fv/shaders.ts
@@ -1,0 +1,77 @@
+export const vertex = /* glsl */ `
+  attribute vec2 aTarget;
+  attribute vec2 aStart;
+  attribute vec2 aRandom;
+  attribute float aBrightness;
+  attribute float aTint;
+
+  uniform vec2 uResolution;
+  uniform float uScale;
+  uniform float uTime;
+  uniform float uProgress;
+  uniform vec2 uMouse;
+  uniform float uPointSize;
+  uniform float uDpr;
+
+  varying float vBrightness;
+  varying float vTint;
+  varying float vEased;
+
+  void main() {
+    vec2 target = aTarget * uScale;
+    vec2 start = aStart * uScale;
+
+    // 粒子ごとにランダムな遅延を付けて収束させる
+    float local = clamp((uProgress - aRandom.x * 0.5) / (1.0 - aRandom.x * 0.5), 0.0, 1.0);
+    float eased = local * local * (3.0 - 2.0 * local);
+
+    vec2 pos = mix(start, target, eased);
+
+    // 常時のゆらぎ
+    float wobble = sin(uTime * 0.6 + aRandom.y * 6.2831853) * (1.4 + aRandom.x * 1.6);
+    float wobbleY = cos(uTime * 0.5 + aRandom.x * 6.2831853) * 1.2;
+    pos += vec2(wobble, wobbleY) * eased;
+
+    vec2 screenPos = pos + uResolution * 0.5;
+
+    // マウス反発
+    vec2 toMouse = screenPos - uMouse;
+    float dist = length(toMouse);
+    float radius = 130.0 * uDpr;
+    float force = smoothstep(radius, 0.0, dist) * eased;
+    vec2 dir = dist > 0.0001 ? normalize(toMouse) : vec2(0.0, 0.0);
+    screenPos += dir * force * 70.0;
+
+    vec2 clip = (screenPos / uResolution) * 2.0 - 1.0;
+    clip.y = -clip.y;
+
+    gl_Position = vec4(clip, 0.0, 1.0);
+    gl_PointSize = uPointSize * uDpr * (0.6 + aBrightness * 0.9) * mix(0.35, 1.0, eased);
+
+    vBrightness = aBrightness;
+    vTint = aTint;
+    vEased = eased;
+  }
+`;
+
+export const fragment = /* glsl */ `
+  precision highp float;
+
+  varying float vBrightness;
+  varying float vTint;
+  varying float vEased;
+
+  void main() {
+    vec2 uv = gl_PointCoord - 0.5;
+    float d = length(uv);
+    if (d > 0.5) discard;
+
+    float alpha = smoothstep(0.5, 0.0, d) * (0.3 + vBrightness * 0.7) * vEased;
+
+    vec3 white = vec3(1.0, 1.0, 1.0);
+    vec3 orange = vec3(0.8902, 0.3451, 0.0); // #e35800
+    vec3 color = mix(white, orange, vTint);
+
+    gl_FragColor = vec4(color, alpha);
+  }
+`;

--- a/src/lib/particleSampler.ts
+++ b/src/lib/particleSampler.ts
@@ -4,7 +4,7 @@ export type ParticlePoint = {
   brightness: number;
 };
 
-type SampleMode = "luminance" | "alpha";
+type SampleMode = "luminance" | "luminance-bright" | "alpha";
 
 type SampleOptions = {
   /** サンプリング用に画像を描画するオフスクリーンcanvasの幅(px) */
@@ -13,7 +13,8 @@ type SampleOptions = {
   maxPoints: number;
   mode: SampleMode;
   /**
-   * luminance モード: これより暗い(背景でない)ピクセルを採用する閾値(0-255)
+   * luminance モード: これより暗い(背景でない)ピクセルを採用する閾値(0-255)。白背景の写真向け。
+   * luminance-bright モード: これより明るいピクセルを採用する閾値(0-255)。黒背景の写真向け。
    * alpha モード: これより不透明なピクセルを採用する閾値(0-255)
    */
   threshold: number;
@@ -71,6 +72,15 @@ export const sampleImageParticles = (
       }
 
       const luminance = r * 0.299 + g * 0.587 + b * 0.114;
+
+      if (mode === "luminance-bright") {
+        if (a > 128 && luminance > threshold) {
+          const brightness = Math.min(1, Math.max(0.25, luminance / 255));
+          candidates.push({ x, y, brightness });
+        }
+        continue;
+      }
+
       if (a > 128 && luminance < threshold) {
         // 暗いピクセルほど黒背景の上で目立つよう明るさを反転させる
         const brightness = Math.min(1, Math.max(0.25, 1 - luminance / 255));


### PR DESCRIPTION
## 概要

トップページのFVを黒基調のままWebGLアニメーションでリニューアルする。参考: https://taro-kashiwagi.com/

## 変更内容

- inabakun.png（顔写真）と "Have Your Inabakun" ロゴを WebGL パーティクル（点群）として再構成
- ロード時に粒子が集まって輪郭を形成 → マウス接近で反発するインタラクション
- 黒基調 / 白文字 / オレンジアクセント（#e35800）の既存配色は踏襲

## 確認方法

- トップページ（`/`）を開き、FVのパーティクルアニメーションとマウスインタラクションを確認