### PR TITLE
カーソル円のブレンドモードをオレンジ色に変更

### DIFF
--- a/src/components/common/AnimatedCursor/AnimatedCursor.tsx
+++ b/src/components/common/AnimatedCursor/AnimatedCursor.tsx
@@ -29,11 +29,12 @@ const CLICKABLE_SELECTOR = [
 ].join(",");
 
 const COLOR = "255, 255, 255";
+const ORANGE = "242, 115, 20";
 const INNER_SIZE = 10;
 const OUTER_SIZE = 20;
 const INNER_SCALE = 0.6;
 const OUTER_SCALE = 6;
-const OUTER_ALPHA = 0.4;
+const OUTER_ALPHA = 1;
 /** 1 フレームあたり残り距離の 1/TRAILING_SPEED だけ outer を進める */
 const TRAILING_SPEED = 8;
 
@@ -166,8 +167,8 @@ const CursorCore = () => {
           ...BASE_STYLE,
           width: OUTER_SIZE,
           height: OUTER_SIZE,
-          backgroundColor: `rgba(${COLOR}, ${OUTER_ALPHA})`,
-          mixBlendMode: "difference",
+          backgroundColor: `rgba(${ORANGE}, ${OUTER_ALPHA})`,
+          mixBlendMode: "color",
         }}
       />
       <div


### PR DESCRIPTION
## 概要
- カスタムカーソルの外側の円に重なった文字・アイコンがオレンジ色に染まるようにした

## 変更内容
- `mix-blend-mode` を `difference`（色反転）から `color` に変更
- 円の背景色を白からブランドオレンジ `rgb(242, 115, 20)`（FVシェーダーで使用中の色と統一）に変更
- 不透明度を `0.4` → `1` に変更（`color` ブレンドで元の色を確実に染めるため）

対象ファイル: `src/components/common/AnimatedCursor/AnimatedCursor.tsx`

## レビュー時の参考
- 内側の小さいドット（カーソル先端）は視認性のため白のまま
- 内蔵ブラウザで `mix-blend-mode: color` のブロックを一時的に重ねて動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)