### PR TITLE
💄 FVの背景画像を薄く調整

### DIFF
--- a/src/components/common/PageTemplate/PageTemplate.tsx
+++ b/src/components/common/PageTemplate/PageTemplate.tsx
@@ -36,7 +36,7 @@ const PageTemplate = (props: PageTemplateProps) => {
        * before: は背景（public/site_bg.svg）をグレースケールで画面に固定するもの。
        * その上に同じ写真からサンプリングしたパーティクルを ParticleBackdrop で重ねる。
        */}
-      <div className="bg-background-main relative mx-auto min-h-screen w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-screen before:w-screen before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:opacity-60 before:grayscale before:content-[''] md:px-[50px]">
+      <div className="bg-background-main relative mx-auto min-h-screen w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-screen before:w-screen before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:opacity-30 before:grayscale before:content-[''] md:px-[50px]">
         <ParticleBackdrop />
         <HeaderNavigation />
         <SnsList />

--- a/src/components/common/ParticleBackdrop/shaders.ts
+++ b/src/components/common/ParticleBackdrop/shaders.ts
@@ -63,7 +63,7 @@ export const fragment = /* glsl */ `
     float d = length(uv);
     if (d > 0.5) discard;
 
-    float alphaBase = mix(0.25, 0.55, vShape) + vBrightness * mix(0.55, 0.9, vShape);
+    float alphaBase = mix(0.14, 0.32, vShape) + vBrightness * mix(0.32, 0.55, vShape);
     float alpha = smoothstep(0.5, 0.0, d) * alphaBase * vAlpha;
 
     vec3 dust = vec3(1.0, 1.0, 1.0);


### PR DESCRIPTION
## 概要

FVの背景モザイク(site_bg.svgと輪郭パーティクル)が濃すぎたため、薄くした。

## 変更内容

- `before:opacity-60` → `before:opacity-30` に変更し、背景画像site_bg.svgを薄くした
- 背景輪郭パーティクル(ParticleBackdrop)のalphaBaseを下げ、モザイク感を軽減した

## 確認方法

- トップページ(FV)を開き、背景の写真・粒子の濃さが以前より薄くなっていることを確認する