### PR TITLE
💄 背景画像をゆっくりズームさせるアニメーションを追加

### DIFF
--- a/src/components/common/PageTemplate/PageTemplate.tsx
+++ b/src/components/common/PageTemplate/PageTemplate.tsx
@@ -36,7 +36,7 @@ const PageTemplate = (props: PageTemplateProps) => {
        * before: は背景（public/site_bg.svg）をグレースケールで画面に固定するもの。
        * その上に同じ写真からサンプリングしたパーティクルを ParticleBackdrop で重ねる。
        */}
-      <div className="bg-background-main relative mx-auto min-h-screen w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-screen before:w-screen before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:opacity-30 before:grayscale before:content-[''] md:px-[50px]">
+      <div className="bg-background-main relative mx-auto min-h-screen w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-screen before:w-screen before:animate-bg-zoom before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:opacity-30 before:grayscale before:content-[''] md:px-[50px]">
         <ParticleBackdrop />
         <HeaderNavigation />
         <SnsList />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,6 +15,18 @@
   --color-background-sub: rgba(1, 1, 1, 0.5);
   /* 旧 COLORS.text.accent。現状どこからも使っていないが値は引き継いでおく */
   --color-text-accent: #e35800;
+
+  /* 背景画像 (site_bg.svg) をゆっくり拡大縮小させるアニメーション */
+  --animate-bg-zoom: bg-zoom 30s ease-in-out infinite alternate;
+}
+
+@keyframes bg-zoom {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.15);
+  }
 }
 
 @layer base {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,8 +16,8 @@
   /* 旧 COLORS.text.accent。現状どこからも使っていないが値は引き継いでおく */
   --color-text-accent: #e35800;
 
-  /* 背景画像 (site_bg.svg) をゆっくり拡大縮小させるアニメーション */
-  --animate-bg-zoom: bg-zoom 30s ease-in-out infinite alternate;
+  /* 背景画像 (site_bg.svg) を1倍から100倍まで7分かけてゆっくりズームさせるアニメーション */
+  --animate-bg-zoom: bg-zoom 420s linear infinite;
 }
 
 @keyframes bg-zoom {
@@ -25,7 +25,7 @@
     transform: scale(1);
   }
   to {
-    transform: scale(1.15);
+    transform: scale(100);
   }
 }
 


### PR DESCRIPTION
## 概要

サイト全体の背景画像 (site_bg.svg) がゆっくり拡大縮小するアニメーションを追加した。

## 変更内容

- `src/styles/global.css` に `bg-zoom` キーフレームと `--animate-bg-zoom` (30秒周期でscale 1→1.15を往復) を追加
- `PageTemplate.tsx` の背景を描画している `before` 疑似要素に `before:animate-bg-zoom` を適用

## 確認方法

- トップページなど任意のページを開き、背景画像がゆっくり拡大縮小することを確認する