### PR TITLE
✏️ profileの自己紹介文を追加・調整

### DIFF
--- a/src/components/pages/profile/ProfileTerminal/ProfileTerminal.tsx
+++ b/src/components/pages/profile/ProfileTerminal/ProfileTerminal.tsx
@@ -38,8 +38,8 @@ const restLines: TerminalLine[] = [
   },
   {
     segments: [
-      { text: "Tokyo, Japan" },
-      { text: " // 東京", className: jaClass },
+      { text: "Izu → Tokyo, Japan" },
+      { text: " // 伊豆出身、東京在住", className: jaClass },
     ],
   },
   {
@@ -61,11 +61,39 @@ const restLines: TerminalLine[] = [
   },
   {
     segments: [
+      { text: "Loves AI and solving problems." },
+      { text: " // AIと課題解決が好き", className: jaClass },
+    ],
+  },
+  {
+    segments: [
+      { text: "$ ", className: promptClass },
+      { text: "cat motto.md", className: commandClass },
+      { text: " // 座右の銘", className: jaClass },
+    ],
+    wrapperClassName: "mt-6",
+  },
+  {
+    segments: [
+      { text: "Don't push yourself too hard." },
+      { text: " // 無理しない", className: jaClass },
+    ],
+  },
+  {
+    segments: [
+      { text: "$ ", className: promptClass },
+      { text: "cat hobbies.md", className: commandClass },
+      { text: " // 趣味", className: jaClass },
+    ],
+    wrapperClassName: "mt-6",
+  },
+  {
+    segments: [
       {
-        text: "Believes AI should redesign not only the product, but how the team builds it.",
+        text: "Sauna, live shows, camping, photography, weight training, cooking.",
       },
       {
-        text: " // AIはプロダクトだけでなく、チームの働き方も作り変えるものだと思っている",
+        text: " // サウナ・ライブ観戦・キャンプ・カメラ・筋トレ・料理",
         className: jaClass,
       },
     ],


### PR DESCRIPTION
## 概要

profileページのターミナル風自己紹介に、出身地・座右の銘・趣味を追加し、自己紹介文をよりシンプルな表現に変更しました。

## 変更内容

- 出身地: `Izu → Tokyo, Japan` // 伊豆出身、東京在住
- 自己紹介文: `Loves AI and solving problems.` // AIと課題解決が好き
- 座右の銘セクション追加: `Don't push yourself too hard.` // 無理しない
- 趣味セクション追加: `Sauna, live shows, camping, photography, weight training, cooking.` // サウナ・ライブ観戦・キャンプ・カメラ・筋トレ・料理

## 確認方法

- `/profile` ページのターミナルアニメーションが最後まで流れ、上記の文言が表示されることを確認