### PR TITLE
💄 SPメニューにSNSアイコン移設+ターミナル風演出

### DIFF
--- a/src/components/common/HeaderNavigation/HeaderNavigation.tsx
+++ b/src/components/common/HeaderNavigation/HeaderNavigation.tsx
@@ -1,5 +1,6 @@
 import NextLink from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
+import SnsList from "../SnsList/SnsList";
 
 const pageList = [
   {
@@ -105,9 +106,23 @@ const HeaderNavigation = () => {
               onClick={onOpen}
               aria-label="メニューを開く"
               aria-expanded={isOpen}
-              className="text-text-accent font-mono text-[13px] tracking-[0.15em] transition-colors duration-300 hover:text-white md:hidden"
+              className="group text-text-accent animate-profile-pulse font-mono text-[13px] tracking-[0.15em] transition-colors duration-300 hover:text-white md:hidden"
             >
-              [ MENU ]
+              {/* コマンドプロンプト風に "$ " を添える */}
+              <span className="text-white/40" aria-hidden="true">
+                ${" "}
+              </span>
+              <span className="mr-1 inline-block transition-transform duration-300 group-hover:-translate-x-0.5">
+                [
+              </span>
+              MENU
+              <span className="ml-1 inline-block transition-transform duration-300 group-hover:translate-x-0.5">
+                ]
+              </span>
+              {/* ターミナルのキャレット点滅 */}
+              <span className="animate-blink ml-1" aria-hidden="true">
+                ▌
+              </span>
             </button>
           </div>
         </div>
@@ -158,7 +173,7 @@ const HeaderNavigation = () => {
                   <NextLink
                     href={page.link}
                     onClick={onClose}
-                    className="group text-text-accent block p-5 font-mono text-[25px] tracking-[0.1em] transition-colors duration-300 hover:text-white"
+                    className="group animate-profile-pulse text-text-accent block p-5 font-mono text-[25px] tracking-[0.1em] transition-colors duration-300 hover:text-white"
                   >
                     <span className="mr-1 inline-block transition-transform duration-300 group-hover:-translate-x-0.5">
                       [
@@ -171,6 +186,11 @@ const HeaderNavigation = () => {
                 </li>
               ))}
             </ul>
+          </div>
+
+          {/* SNS リンク: PC では右下固定 (SnsList variant="fixed") だが、SP はスペースが狭いのでメニュー内にまとめる */}
+          <div className="pb-8">
+            <SnsList variant="inline" />
           </div>
         </div>
       )}

--- a/src/components/common/SnsList/SnsList.tsx
+++ b/src/components/common/SnsList/SnsList.tsx
@@ -1,4 +1,4 @@
-const snsLinkList = [
+export const snsLinkList = [
   {
     link: "https://www.instagram.com/purupuruboy2?igsh=dDB0cDd2dGN2bHEw&utm_source=qr",
     image: "icon-instagram.svg",
@@ -16,14 +16,28 @@ const snsLinkList = [
   },
 ];
 
-const SnsList = () => {
+type SnsListProps = {
+  // "fixed": PC で画面右下に固定表示するレイアウト (SP は HeaderNavigation のメニュー内に出すのでここでは隠す)
+  // "inline": メニュードロワーなど、別の場所に横並びで埋め込むレイアウト
+  variant?: "fixed" | "inline";
+};
+
+const SnsList = ({ variant = "fixed" }: SnsListProps) => {
+  const isFixed = variant === "fixed";
+
   return (
-    <div className="fixed right-[15px] bottom-[15px] z-[1100]">
-      <ul>
+    <div
+      className={
+        isFixed
+          ? "fixed right-[15px] bottom-[15px] z-[1100] hidden md:block"
+          : undefined
+      }
+    >
+      <ul className={isFixed ? undefined : "flex justify-center gap-x-6"}>
         {snsLinkList.map((snsLink, index) => (
           <li
             key={snsLink.name}
-            className={index === 0 ? undefined : "mt-[15px]"}
+            className={isFixed && index !== 0 ? "mt-[15px]" : undefined}
           >
             {/* target / rel は Chakra の Link isExternal が付けていたものを引き継ぐ */}
             <a href={snsLink.link} target="_blank" rel="noopener noreferrer">

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -15,8 +15,8 @@ const Profile: NextPage = () => {
           rel="stylesheet"
         ></link>
       </Head>
-      {/* pr は右下固定の SnsList (幅40px + right-15px) とターミナルの枠線が被らないための余白 */}
-      <div className="mt-[50px] flex flex-col gap-[30px] pr-[70px] md:mt-[100px] md:gap-[50px] md:pr-[90px]">
+      {/* md:pr は PC のみ右下固定表示される SnsList (幅40px + right-15px) とターミナルの枠線が被らないための余白。SP は SnsList をメニュー内に出すので不要 */}
+      <div className="mt-[50px] flex flex-col gap-[30px] md:mt-[100px] md:gap-[50px] md:pr-[90px]">
         <ProfileTerminal />
         <CareerTerminal />
         <SkillTerminal />


### PR DESCRIPTION
## 概要

スマホ表示のprofileページで、右下固定のSNSアイコンがターミナル表示幅を圧迫していた問題と、MENUボタン/メニュー項目にもターミナル端末らしい装飾を加えたいという要望への対応。

## 変更内容

- SNSアイコンをSP (`md:` 未満) では非表示にし、代わりにハンバーガーメニュー(ドロワー)内に横並びで表示するように変更
- 上記に伴い、profileページ側でSNSアイコン用に確保していたSP用の余白 (`pr-[70px]`) を削除し、ターミナルの表示幅を拡大
- メニュー内の `[ profile ]` リンクにPCナビと同じグロウ点滅アニメーションを追加
- `[ MENU ]` ボタンに `$ ` プロンプト表記とキャレット点滅・グロウ点滅を追加し、ターミナル端末らしい見た目に

## 確認方法

- `/profile` をスマホ幅で表示し、ターミナルがSNSアイコンに幅を取られず全幅表示されることを確認
- ハンバーガーメニューを開き、SNSアイコンがメニュー下部に表示されること、`[ profile ]` と `[ MENU ]` がグロウ点滅・キャレット点滅することを確認
- PC幅では従来通りSNSアイコンが右下固定表示されることを確認