### PR TITLE
🔧 SEO対応(title/meta description/OGP/構造化データ等)を追加

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/src/components/common/PageTemplate/PageTemplate.tsx
+++ b/src/components/common/PageTemplate/PageTemplate.tsx
@@ -8,7 +8,7 @@ import { motion } from "framer-motion";
 const SITE_URL = "https://www.inabakun.com";
 const SITE_NAME = "Have Your Inabakun";
 const DEFAULT_DESCRIPTION =
-  "フロントエンドエンジニア・デザイナー稲葉勇人(Hayato Inaba)のポートフォリオサイト「Have Your Inabakun」。伊豆出身、東京在住。経歴やスキルを紹介しています。";
+  "フロントエンドエンジニア・デザイナー稲葉勇人（イナバくん）のポートフォリオサイト「Have Your Inabakun」。伊豆出身、東京在住。経歴やスキルを紹介しています。";
 
 type PageTemplateProps = {
   // サブページのタイトル。指定すると "${pageTitle} | Have Your Inabakun" になる
@@ -71,8 +71,8 @@ const PageTemplate = ({
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "Person",
-              name: "Hayato Inaba",
-              alternateName: "稲葉勇人",
+              name: "稲葉勇人",
+              alternateName: "イナバくん",
               jobTitle: "Front-end Engineer / Designer",
               url: SITE_URL,
               image: ogImageUrl,

--- a/src/components/common/PageTemplate/PageTemplate.tsx
+++ b/src/components/common/PageTemplate/PageTemplate.tsx
@@ -5,32 +5,85 @@ import SnsList from "../SnsList/SnsList";
 import ParticleBackdrop from "../ParticleBackdrop/ParticleBackdrop";
 import { motion } from "framer-motion";
 
+const SITE_URL = "https://www.inabakun.com";
+const SITE_NAME = "Have Your Inabakun";
+const DEFAULT_DESCRIPTION =
+  "フロントエンドエンジニア・デザイナー稲葉勇人(Hayato Inaba)のポートフォリオサイト「Have Your Inabakun」。伊豆出身、東京在住。経歴やスキルを紹介しています。";
+
 type PageTemplateProps = {
+  // サブページのタイトル。指定すると "${pageTitle} | Have Your Inabakun" になる
   pageTitle?: string;
+  // タイトルをサフィックスなしで完全に上書きしたいときに使う(未指定なら pageTitle から組み立て)
+  title?: string;
+  // 省略時はサイト共通の説明文
+  description?: string;
+  // 絶対URLの組み立てに使うパス。"/profile" のように先頭は "/"
+  canonicalPath?: string;
+  // 404 など検索結果に出したくないページで true にする
+  noIndex?: boolean;
   children: ReactNode;
 };
 
-const PageTemplate = (props: PageTemplateProps) => {
+const PageTemplate = ({
+  pageTitle,
+  title,
+  description = DEFAULT_DESCRIPTION,
+  canonicalPath = "/",
+  noIndex = false,
+  children,
+}: PageTemplateProps) => {
+  const pageFullTitle =
+    title ?? (pageTitle ? `${pageTitle} | ${SITE_NAME}` : SITE_NAME);
+  const canonicalUrl = `${SITE_URL}${canonicalPath}`;
+  const ogImageUrl = `${SITE_URL}/ogp.jpg`;
+
   return (
     <>
       <Head>
-        <title>
-          {props.pageTitle && `${props.pageTitle} | `}Have Your Inabakun
-        </title>
+        <title>{pageFullTitle}</title>
         <link
           href="https://fonts.googleapis.com/css2?family=Playfair+Display&display=swap"
           rel="stylesheet"
         ></link>
-        <meta
-          name="description"
-          content="Have Your Inabakun. イナバくんのポートフォリオサイトです。 稲葉勇人"
+        <meta name="description" content={description} />
+        <link rel="canonical" href={canonicalUrl} />
+        {noIndex && <meta name="robots" content="noindex,nofollow" />}
+
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content={SITE_NAME} />
+        <meta property="og:locale" content="ja_JP" />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:title" content={pageFullTitle} />
+        <meta property="og:description" content={description} />
+        <meta property="og:image" content={ogImageUrl} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageFullTitle} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={ogImageUrl} />
+        <meta name="twitter:site" content="@dev_inabakun" />
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "Person",
+              name: "Hayato Inaba",
+              alternateName: "稲葉勇人",
+              jobTitle: "Front-end Engineer / Designer",
+              url: SITE_URL,
+              image: ogImageUrl,
+              sameAs: [
+                "https://twitter.com/dev_inabakun",
+                "https://github.com/inabakun178",
+                "https://www.instagram.com/purupuruboy2",
+              ],
+            }),
+          }}
         />
-        <meta property="og:title" content={"Have Your Inabakun"} />
-        <meta
-          name="og:description"
-          content="Have Your Inabakun. イナバくんのポートフォリオサイトです。 稲葉勇人"
-        />
-        <meta property="og:image" content="https://www.inabakun.com/ogp.jpg" />
       </Head>
       {/*
        * before: は背景（public/site_bg.svg）をグレースケールで画面に固定するもの。
@@ -47,7 +100,7 @@ const PageTemplate = (props: PageTemplateProps) => {
             animate={{ opacity: 1 }} // マウント時
             exit={{ opacity: 0 }} // アンマウント時
           >
-            {props.children}
+            {children}
           </motion.div>
         </div>
       </div>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -3,7 +3,12 @@ import PageTemplate from "../components/common/PageTemplate/PageTemplate";
 
 const Home: NextPage = () => {
   return (
-    <PageTemplate pageTitle="404">
+    <PageTemplate
+      pageTitle="404 Not Found"
+      description="お探しのページは見つかりませんでした。"
+      canonicalPath="/404"
+      noIndex
+    >
       <p className="text-center text-[120px] text-white/50 md:text-[300px]">
         404
       </p>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="ja">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,11 @@ import Fv from "../components/pages/top/Fv/Fv";
 // TODO: import のパスをエイリアスにしたい
 const Home: NextPage = () => {
   return (
-    <PageTemplate>
+    <PageTemplate
+      title="Have Your Inabakun | 稲葉勇人(Hayato Inaba)のポートフォリオサイト"
+      description="フロントエンドエンジニア・デザイナー稲葉勇人(Hayato Inaba)のポートフォリオサイト。伊豆出身、東京在住。UI/UXデザインとフロントエンド開発の実績、経歴、スキルを紹介しています。"
+      canonicalPath="/"
+    >
       <Fv />
       {/* TODO: scroll button置く */}
       {/* TODO: 実績リスト置く */}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,8 +7,8 @@ import Fv from "../components/pages/top/Fv/Fv";
 const Home: NextPage = () => {
   return (
     <PageTemplate
-      title="Have Your Inabakun | 稲葉勇人(Hayato Inaba)のポートフォリオサイト"
-      description="フロントエンドエンジニア・デザイナー稲葉勇人(Hayato Inaba)のポートフォリオサイト。伊豆出身、東京在住。UI/UXデザインとフロントエンド開発の実績、経歴、スキルを紹介しています。"
+      title="Have Your Inabakun | 稲葉勇人（イナバくん）のポートフォリオサイト"
+      description="フロントエンドエンジニア・デザイナー稲葉勇人（イナバくん）のポートフォリオサイト。伊豆出身、東京在住。UI/UXデザインとフロントエンド開発の実績、経歴、スキルを紹介しています。"
       canonicalPath="/"
     >
       <Fv />

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -8,7 +8,7 @@ import SkillTerminal from "../../components/pages/profile/SkillTerminal/SkillTer
 const Profile: NextPage = () => {
   return (
     <PageTemplate
-      pageTitle="プロフィール・経歴・スキル"
+      pageTitle="PROFILE"
       description="フロントエンドエンジニア・デザイナー稲葉勇人(Hayato Inaba)のプロフィール紹介ページ。経歴、スキル、得意分野を掲載しています。"
       canonicalPath="/profile"
     >

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -7,7 +7,11 @@ import SkillTerminal from "../../components/pages/profile/SkillTerminal/SkillTer
 
 const Profile: NextPage = () => {
   return (
-    <PageTemplate pageTitle="Profile">
+    <PageTemplate
+      pageTitle="プロフィール・経歴・スキル"
+      description="フロントエンドエンジニア・デザイナー稲葉勇人(Hayato Inaba)のプロフィール紹介ページ。経歴、スキル、得意分野を掲載しています。"
+      canonicalPath="/profile"
+    >
       <Head>
         {/* ターミナルUI用の等幅フォント。PageTemplate の Head とマージされる */}
         <link

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -9,7 +9,7 @@ const Profile: NextPage = () => {
   return (
     <PageTemplate
       pageTitle="PROFILE"
-      description="フロントエンドエンジニア・デザイナー稲葉勇人(Hayato Inaba)のプロフィール紹介ページ。経歴、スキル、得意分野を掲載しています。"
+      description="フロントエンドエンジニア・デザイナー稲葉勇人（イナバくん）のプロフィール紹介ページ。経歴、スキル、得意分野を掲載しています。"
       canonicalPath="/profile"
     >
       <Head>


### PR DESCRIPTION
## 概要

title・meta description・OGP・Twitter Card・canonical・構造化データ(JSON-LD)・robots.txt・sitemap.xml など、SEOまわりの実装が不足していたため一通り整備する。

## 変更内容

- ページごとに title / meta description を最適化(トップ・プロフィール)
- OGP・Twitter Card meta を修正・追加(誤っていた og:description の属性名も修正)
- canonical URL、og:url、og:type、og:locale、og:site_name を追加
- Person構造化データ(JSON-LD)を追加
- robots.txt / sitemap.xml を追加
- html の lang="ja" を明示(_document.tsx 追加)

## 確認方法

- 各ページの view-source で title / meta タグを確認
- https://search.google.com/test/rich-results 等で構造化データを確認(任意)
- /robots.txt /sitemap.xml にアクセスして内容を確認