### PR TITLE
📝 完了済みタスクをtodo.mdでチェック

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -6,34 +6,34 @@
 
 ## 依存関係
 
-- [ ] ライブラリ更新（Next.js / React / 各種依存パッケージ）
+- [x] ライブラリ更新（Next.js / React / 各種依存パッケージ）
 
 ## サイトデザインリニューアル
 
-- [ ] FV を WebGL でかっこよくする
-- [ ] 問い合わせ導線を SNS に変更する
-- [ ] 実績・プロフィールの内容を更新する
-- [ ] 生年月日を消す
+- [x] FV を WebGL でかっこよくする
+- [x] 問い合わせ導線を SNS に変更する
+- [x] 実績・プロフィールの内容を更新する
+- [x] 生年月日を消す
 
 ## favicon / アイコン
 
-- [ ] favicon を最新化する（現状 `public/favicon.ico` のみ）
+- [x] favicon を最新化する（現状 `public/favicon.ico` のみ）
 - [ ] SVG favicon・apple-touch-icon・192/512px の PNG を追加する
 - [ ] `site.webmanifest` を追加して PWA アイコン・テーマカラーを設定する
 
 ## OGP / SEO
 
 - [ ] OGP 画像（`public/ogp.jpg`）を新デザインに合わせて更新する
-- [ ] 不足している OGP タグを追加する（`og:type` / `og:url` / `og:site_name` / `og:locale`）
-- [ ] `og:description` が `name=` になっているので `property=` に修正する（[PageTemplate.tsx:30](src/components/common/PageTemplate/PageTemplate.tsx:30)）
-- [ ] Twitter Card タグを追加する（`twitter:card` / `twitter:site` など）
-- [ ] ページごとの description・OGP を出し分けられるようにする（現状は全ページ共通の固定文言）
-- [ ] canonical URL を出力する
-- [ ] `robots.txt` と `sitemap.xml` を生成する
-- [ ] 構造化データ（JSON-LD / Person・WebSite）を追加する
-- [ ] `_document` を追加して `<html lang="ja">` を設定する
+- [x] 不足している OGP タグを追加する（`og:type` / `og:url` / `og:site_name` / `og:locale`）
+- [x] `og:description` が `name=` になっているので `property=` に修正する（[PageTemplate.tsx:30](src/components/common/PageTemplate/PageTemplate.tsx:30)）
+- [x] Twitter Card タグを追加する（`twitter:card` / `twitter:site` など）
+- [x] ページごとの description・OGP を出し分けられるようにする（現状は全ページ共通の固定文言）
+- [x] canonical URL を出力する
+- [x] `robots.txt` と `sitemap.xml` を生成する
+- [x] 構造化データ（JSON-LD / Person・WebSite）を追加する
+- [x] `_document` を追加して `<html lang="ja">` を設定する
 
 ## 開発基盤
 
-- [ ] CI を作る（テスト、lint、型チェック、build）
+- [x] CI を作る（テスト、lint、型チェック、build）
 - [x] Chakra UI から Tailwind CSS に移行する（対応表と落とし穴は [docs/tailwind-migration.md](docs/tailwind-migration.md)）


### PR DESCRIPTION
## 概要

完了しているタスクを todo.md 上でチェック済みにする。

## 変更内容

- 依存関係（ライブラリ更新）
- サイトデザインリニューアル（FV WebGL化・SNS導線・実績プロフィール更新・生年月日削除）
- favicon 最新化
- OGP / SEO 一式（タグ追加・description修正・Twitter Card・canonical・robots.txt/sitemap.xml・構造化データ・_document）
- CI 構築

をそれぞれチェック済みに変更。

## 確認方法

- todo.md を確認