### PR TITLE
📝 マージ後のstash掃除手順をpr-workflowに追加

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -325,6 +325,34 @@ worktree で作業していた場合は、ブランチを消す前に worktree �
 git worktree remove <path>
 ```
 
+### 取り込み済み stash の掃除
+
+複数セッション運用（上記「⚠️ 複数セッションが同時にこのリポジトリで動く場合の注意」）では、
+他セッションの変更を退避するために `git stash push -m "other-session-wip" -- <file>...`
+を使う場面がある。マージ後にそのブランチの stash が残ったままだと `git stash list` が
+どんどん膨らみ、どれが有効でどれが不要か分からなくなる。ブランチを片付けるタイミングで
+併せて確認する。
+
+```bash
+git stash list
+```
+
+`On <branch-name>: ...` の形式で、いま片付けたブランチ名が含まれる stash があれば対象。
+中身が「マージ済みの変更と同じかどうか」を機械的に確認してから消す（見た目だけで判断しない）:
+
+```bash
+git stash show -p "stash@{N}" > /tmp/stash_N.patch
+git apply --check --reverse /tmp/stash_N.patch
+```
+
+- **エラーなし（exit 0）** → その stash の変更は既に現在のツリーに存在する＝取り込み済み。
+  `git stash drop "stash@{N}"` で消してよい
+- **エラーあり** → 一部でも未取り込みの差分が残っている。安易に消すと他セッションの
+  未完了作業を失うので、**消さずにユーザーに確認する**（何の作業か分からなければ
+  なおさら聞く）
+
+index が大きい stash から順に drop する（小さい番号から消すと後続の番号がずれる）。
+
 ---
 
 ## うっかり main で作業を始めてしまったとき


### PR DESCRIPTION
## 概要

取り込み済みのgit stashが溜まっていたため整理し、今後は同じ状態にならないよう
pr-workflowスキルにマージ後のstash掃除手順を追記した。

## 変更内容

- `.claude/skills/pr-workflow/SKILL.md` の「7. マージ後」に取り込み済みstashの
  掃除手順を追加。`git apply --check --reverse` で機械的に取り込み済みか判定し、
  未取り込みの分はユーザー確認なしに消さないルールを明記。

## 確認方法

- ドキュメントのみの変更のため、内容のレビューでOK