### PR TITLE
スマホ表示の背景粒子とターミナル背景の視認性を調整

### DIFF
--- a/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
+++ b/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
@@ -261,6 +261,8 @@ const ParticleBackdrop = () => {
           uParallax: { value: [0, 0] },
           uPointSize: { value: 2.7 },
           uDpr: { value: renderer.dpr },
+          // スマホでは背景画像がより透けて見えるよう、粒子を0.1薄くする
+          uMobileDim: { value: isCoarsePointer ? 0.1 : 0 },
         },
       });
 

--- a/src/components/effects/ParticleBackdrop/shaders.ts
+++ b/src/components/effects/ParticleBackdrop/shaders.ts
@@ -62,6 +62,8 @@ export const vertex = /* glsl */ `
 export const fragment = /* glsl */ `
   precision highp float;
 
+  uniform float uMobileDim;
+
   varying float vBrightness;
   varying float vAlpha;
   varying float vShape;
@@ -76,7 +78,10 @@ export const fragment = /* glsl */ `
     // (輪郭粒子の濃さは維持しつつ、背景に散らばる粒子(vShape=0)は薄くする)
     float alphaBase =
       mix(0.11, 0.425, vShape) + vBrightness * mix(0.09, 0.5, vShape);
-    float alpha = smoothstep(0.5, 0.0, d) * alphaBase * vAlpha;
+    // スマホでは背景画像がより見えるよう、背景に散らばる粒子(vShape=0)を
+    // 追加で薄くする(輪郭粒子は視認性のため対象外)
+    alphaBase -= uMobileDim * (1.0 - vShape);
+    float alpha = smoothstep(0.5, 0.0, d) * max(alphaBase, 0.0) * vAlpha;
 
     // FVロゴ(オレンジ〜レッド)と色が競合して視認性が下がらないよう、
     // 背景粒子はグレーに統一する

--- a/src/components/profile/TerminalWindow/TerminalWindow.tsx
+++ b/src/components/profile/TerminalWindow/TerminalWindow.tsx
@@ -22,7 +22,7 @@ const TerminalWindow = (props: TerminalWindowProps) => {
       animate={{ opacity: 1, scaleY: 1, y: 0 }}
       transition={{ duration: 1, delay: bootDelay, ease: "easeOut" }}
       style={{ transformOrigin: "top" }}
-      className="border-text-accent/40 bg-cyber-bg relative overflow-hidden rounded-md border font-mono"
+      className="border-text-accent/40 relative overflow-hidden rounded-md border bg-[rgba(1,1,1,0.7)] font-mono md:bg-cyber-bg"
     >
       <div className="border-text-accent/30 bg-text-accent/5 flex items-center gap-2 border-b px-4 py-2 md:px-6">
         <span className="text-text-accent text-[12px] md:text-[14px]">


### PR DESCRIPTION
## Summary
- スマホ(タッチ主体端末)表示時、背景の白い粒子(輪郭以外の周囲に散らばる粒子)のopacityを0.1薄くし、背景画像がより見えるようにした
- profileページのターミナルウィンドウの黒背景を、スマホ表示時のみopacityを0.1濃くし、日本語コメントの視認性を上げた

## Changes
- `src/components/effects/ParticleBackdrop/shaders.ts`: フラグメントシェーダーに `uMobileDim` uniformを追加し、背景粒子(輪郭粒子は除く)のalphaを減算
- `src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx`: 既存の `isCoarsePointer` 判定を使い、タッチ主体端末では `uMobileDim` を0.1に設定
- `src/components/profile/TerminalWindow/TerminalWindow.tsx`: モバイルではターミナル背景を `rgba(1,1,1,0.7)`、`md:`以上では従来の `bg-cyber-bg` (0.6) を使うよう変更

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] 実機/DevToolsのモバイルビューでの目視確認(未実施)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QbW945DXzhWEi4HMu2CtU7)_