### PR TITLE
スマホの背景粒子/ターミナル背景の視認性調整と粒子・線のカラー変更

### DIFF
--- a/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
+++ b/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
@@ -261,8 +261,6 @@ const ParticleBackdrop = () => {
           uParallax: { value: [0, 0] },
           uPointSize: { value: 2.7 },
           uDpr: { value: renderer.dpr },
-          // スマホでは背景画像がより透けて見えるよう、粒子を0.2薄くする
-          uMobileDim: { value: isCoarsePointer ? 0.2 : 0 },
         },
       });
 

--- a/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
+++ b/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
@@ -261,8 +261,8 @@ const ParticleBackdrop = () => {
           uParallax: { value: [0, 0] },
           uPointSize: { value: 2.7 },
           uDpr: { value: renderer.dpr },
-          // スマホでは背景画像がより透けて見えるよう、粒子を0.1薄くする
-          uMobileDim: { value: isCoarsePointer ? 0.1 : 0 },
+          // スマホでは背景画像がより透けて見えるよう、粒子を0.2薄くする
+          uMobileDim: { value: isCoarsePointer ? 0.2 : 0 },
         },
       });
 

--- a/src/components/effects/ParticleBackdrop/shaders.ts
+++ b/src/components/effects/ParticleBackdrop/shaders.ts
@@ -97,8 +97,8 @@ export const lineFragment = /* glsl */ `
 
   void main() {
     vec3 gray = vec3(0.78, 0.78, 0.78);
-    // 線が濃く見えすぎていたため、輪郭粒子と同じく0.6倍に抑えて透過させる
-    float alpha = (0.6 + vBrightness * 0.4) * vAlpha * 0.6;
+    // 線が濃く見えすぎていたため、0.3倍に抑えて透過させる
+    float alpha = (0.6 + vBrightness * 0.4) * vAlpha * 0.3;
     gl_FragColor = vec4(gray, alpha);
   }
 `;

--- a/src/components/effects/ParticleBackdrop/shaders.ts
+++ b/src/components/effects/ParticleBackdrop/shaders.ts
@@ -82,6 +82,9 @@ export const fragment = /* glsl */ `
     // 追加で薄くする(輪郭粒子は視認性のため対象外)
     alphaBase -= uMobileDim * (1.0 - vShape);
     float alpha = smoothstep(0.5, 0.0, d) * max(alphaBase, 0.0) * vAlpha;
+    // 輪郭粒子(vShape=1)がほぼ不透明に見えていたため、PC/スマホ問わず
+    // 0.6倍に抑えて透過させる(周辺の散らばり粒子(vShape=0)は変更しない)
+    alpha *= mix(1.0, 0.6, vShape);
 
     // FVロゴ(オレンジ〜レッド)と色が競合して視認性が下がらないよう、
     // 背景粒子はグレーに統一する

--- a/src/components/effects/ParticleBackdrop/shaders.ts
+++ b/src/components/effects/ParticleBackdrop/shaders.ts
@@ -82,7 +82,7 @@ export const fragment = /* glsl */ `
 
     // FVロゴ(オレンジ〜レッド)と色が競合して視認性が下がらないよう、
     // 背景粒子はグレーに統一する
-    vec3 color = vec3(0.72, 0.72, 0.72);
+    vec3 color = vec3(0.35, 0.35, 0.35);
 
     gl_FragColor = vec4(color, alpha);
   }
@@ -96,7 +96,7 @@ export const lineFragment = /* glsl */ `
   varying float vAlpha;
 
   void main() {
-    vec3 gray = vec3(0.78, 0.78, 0.78);
+    vec3 gray = vec3(0.4, 0.4, 0.4);
     // 線が濃く見えすぎていたため、0.3倍に抑えて透過させる
     float alpha = (0.6 + vBrightness * 0.4) * vAlpha * 0.3;
     gl_FragColor = vec4(gray, alpha);

--- a/src/components/effects/ParticleBackdrop/shaders.ts
+++ b/src/components/effects/ParticleBackdrop/shaders.ts
@@ -62,8 +62,6 @@ export const vertex = /* glsl */ `
 export const fragment = /* glsl */ `
   precision highp float;
 
-  uniform float uMobileDim;
-
   varying float vBrightness;
   varying float vAlpha;
   varying float vShape;
@@ -75,13 +73,9 @@ export const fragment = /* glsl */ `
 
     // 人型の輪郭(vShape=1)を周囲の散らばり粒子(vShape=0)よりはっきり
     // 見せることで、粒子+線で人の形が読み取れるようにする
-    // (輪郭粒子の濃さは維持しつつ、背景に散らばる粒子(vShape=0)は薄くする)
     float alphaBase =
       mix(0.11, 0.425, vShape) + vBrightness * mix(0.09, 0.5, vShape);
-    // スマホでは背景画像がより見えるよう、背景に散らばる粒子(vShape=0)を
-    // 追加で薄くする(輪郭粒子は視認性のため対象外)
-    alphaBase -= uMobileDim * (1.0 - vShape);
-    float alpha = smoothstep(0.5, 0.0, d) * max(alphaBase, 0.0) * vAlpha;
+    float alpha = smoothstep(0.5, 0.0, d) * alphaBase * vAlpha;
     // 輪郭粒子(vShape=1)がほぼ不透明に見えていたため、PC/スマホ問わず
     // 0.6倍に抑えて透過させる(周辺の散らばり粒子(vShape=0)は変更しない)
     alpha *= mix(1.0, 0.6, vShape);
@@ -103,7 +97,8 @@ export const lineFragment = /* glsl */ `
 
   void main() {
     vec3 gray = vec3(0.78, 0.78, 0.78);
-    float alpha = (0.6 + vBrightness * 0.4) * vAlpha;
+    // 線が濃く見えすぎていたため、輪郭粒子と同じく0.6倍に抑えて透過させる
+    float alpha = (0.6 + vBrightness * 0.4) * vAlpha * 0.6;
     gl_FragColor = vec4(gray, alpha);
   }
 `;

--- a/src/components/profile/TerminalWindow/TerminalWindow.tsx
+++ b/src/components/profile/TerminalWindow/TerminalWindow.tsx
@@ -22,7 +22,7 @@ const TerminalWindow = (props: TerminalWindowProps) => {
       animate={{ opacity: 1, scaleY: 1, y: 0 }}
       transition={{ duration: 1, delay: bootDelay, ease: "easeOut" }}
       style={{ transformOrigin: "top" }}
-      className="border-text-accent/40 relative overflow-hidden rounded-md border bg-[rgba(1,1,1,0.7)] font-mono md:bg-cyber-bg"
+      className="border-text-accent/40 relative overflow-hidden rounded-md border bg-[rgba(1,1,1,0.8)] font-mono md:bg-cyber-bg"
     >
       <div className="border-text-accent/30 bg-text-accent/5 flex items-center gap-2 border-b px-4 py-2 md:px-6">
         <span className="text-text-accent text-[12px] md:text-[14px]">


### PR DESCRIPTION
## Summary
- profileページのターミナルウィンドウの黒背景を、スマホ表示時のみopacityを0.1濃くした(0.6→0.7→0.8)
- 背景の輪郭粒子(人型を形作る粒子)がほぼ不透明に見えていたため、PC/スマホ問わずalphaを0.6倍にして透過させた
- 輪郭粒子どうしを結ぶ線も濃すぎたため、alphaを0.3倍にしてさらに透過させた
- 粒子・線の色を白寄りのグレー(rgb 0.72 / 0.78)から黒寄りのグレー(rgb 0.35 / 0.4)に変更した
- 周辺に散らばる粒子(輪郭以外)のスマホ限定の減光は、確認の結果不要と判断し撤回した

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Vercelプレビューでの目視確認

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QbW945DXzhWEi4HMu2CtU7)_