### PR TITLE
🐛 スマホでの余計な下部スクロール・黒帯を修正

### DIFF
--- a/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
+++ b/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
@@ -390,7 +390,7 @@ const ParticleBackdrop = () => {
     <div
       ref={containerRef}
       aria-hidden
-      className="pointer-events-none fixed top-0 left-0 h-screen w-screen"
+      className="pointer-events-none fixed top-0 left-0 h-dvh w-screen"
     />
   );
 };

--- a/src/components/layout/PageTemplate/PageTemplate.tsx
+++ b/src/components/layout/PageTemplate/PageTemplate.tsx
@@ -13,7 +13,7 @@ const PageTemplate = ({ children }: PageTemplateProps) => {
   return (
     // before: は背景（public/site_bg.svg）をグレースケールで画面に固定するもの。
     // その上に同じ写真からサンプリングしたパーティクルを ParticleBackdrop で重ねる。
-    <div className="bg-background-main relative mx-auto min-h-screen w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-screen before:w-screen before:animate-bg-zoom before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:content-[''] md:px-[50px]">
+    <div className="bg-background-main relative mx-auto min-h-dvh w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-dvh before:w-screen before:animate-bg-zoom before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:content-[''] md:px-[50px]">
       <ParticleBackdrop />
       <HeaderNavigation />
       <SnsList />

--- a/src/components/top/Fv/Fv.tsx
+++ b/src/components/top/Fv/Fv.tsx
@@ -3,7 +3,7 @@ import ParticlePortrait from "./ParticlePortrait";
 
 const Fv = () => {
   return (
-    <div className="flex min-h-[calc(100vh_-_50px)] items-center justify-center md:min-h-[calc(100vh_-_100px)]">
+    <div className="flex min-h-[calc(100dvh_-_50px)] items-center justify-center md:min-h-[calc(100dvh_-_100px)]">
       <ParticlePortrait />
     </div>
   );


### PR DESCRIPTION
## 概要

スマホでサイト下部に余計なスクロールと真っ黒な領域が発生する問題を修正。

原因は `100vh` / `min-h-screen` の使用箇所。モバイルブラウザではアドレスバー表示時の
実際に見えている高さより `100vh` の方が大きくなる（アドレスバーが隠れたときの最大の
高さを基準にする実装のため）。そのため高さを `100vh` 基準で決めていた要素が実際の
可視領域より下に伸び、その分だけ余計にスクロールできる真っ黒な余白ができていた。

## 変更内容

- `PageTemplate`: 外枠の `min-h-screen` と背景疑似要素の `before:h-screen` を `dvh`（動的ビューポート高さ）に変更
- `ParticleBackdrop`: 背景キャンバスのコンテナ高さを `h-screen` → `h-dvh` に変更
- `Fv`（TOPページのファーストビュー）: `calc(100vh - ...)` を `calc(100dvh - ...)` に変更

## 確認方法

- スマホ（実機 or Chrome DevTools のモバイルエミュレーション）で TOP ページ・PROFILE ページを開き、
  アドレスバーが表示された状態でページ最下部までスクロールしても、コンテンツの下に
  黒い余白が残らないことを確認
- PC 表示に見た目の差が無いことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vap7jMmYa3fSkNVmhDPsLs)_