### PR TITLE
✨ Google検索のリッチリザルト対応（sitemap・構造化データ・アイコン）

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Have Your Inabakun",
+  "short_name": "Inabakun",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/inabakun-face.png",
+      "sizes": "235x235",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,13 @@ import type { ReactNode } from "react";
 import { Playfair_Display, JetBrains_Mono } from "next/font/google";
 import "@/styles/global.css";
 import Providers from "./providers";
-import { SITE_URL, SITE_NAME, DEFAULT_DESCRIPTION } from "@/lib/seo";
+import {
+  SITE_URL,
+  SITE_NAME,
+  DEFAULT_DESCRIPTION,
+  personJsonLd,
+  siteNavigationJsonLd,
+} from "@/lib/seo";
 
 const playfairDisplay = Playfair_Display({
   subsets: ["latin"],
@@ -34,22 +40,14 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     site: "@dev_inabakun",
   },
-};
-
-// サイト全体で使い回す Person 構造化データ(JSON-LD)
-const personJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Person",
-  name: "稲葉勇人",
-  alternateName: "イナバくん",
-  jobTitle: "Front-end Engineer / Designer",
-  url: SITE_URL,
-  image: `${SITE_URL}/ogp.jpg`,
-  sameAs: [
-    "https://twitter.com/dev_inabakun",
-    "https://github.com/inabakun178",
-    "https://www.instagram.com/purupuruboy2",
-  ],
+  manifest: "/manifest.json",
+  icons: {
+    icon: [
+      { url: "/favicon.ico" },
+      { url: "/inabakun-face.png", type: "image/png" },
+    ],
+    apple: "/inabakun-face.png",
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
@@ -62,6 +60,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(siteNavigationJsonLd),
+          }}
         />
         <Providers>{children}</Providers>
       </body>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,7 +3,7 @@ import PageTemplate from "@/components/layout/PageTemplate/PageTemplate";
 import ProfileTerminal from "@/components/profile/ProfileTerminal/ProfileTerminal";
 import CareerTerminal from "@/components/profile/CareerTerminal/CareerTerminal";
 import SkillTerminal from "@/components/profile/SkillTerminal/SkillTerminal";
-import { buildMetadata } from "@/lib/seo";
+import { buildMetadata, SITE_URL, SITE_NAME, personJsonLd } from "@/lib/seo";
 
 export const metadata: Metadata = buildMetadata({
   title: "PROFILE",
@@ -12,9 +12,42 @@ export const metadata: Metadata = buildMetadata({
   path: "/profile",
 });
 
+// パンくずリスト（Home > Profile）の JSON-LD
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: SITE_NAME, item: SITE_URL },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Profile",
+      item: `${SITE_URL}/profile`,
+    },
+  ],
+};
+
+// ページ全体を ProfilePage として Person に紐付ける JSON-LD
+const profilePageJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  url: `${SITE_URL}/profile`,
+  mainEntity: personJsonLd,
+};
+
 export default function Profile() {
   return (
     <PageTemplate>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(profilePageJsonLd),
+        }}
+      />
       {/* ターミナルのプロンプト風見出し。他ページに h1 が無いのでここで補う */}
       <h1 className="mt-[50px] flex items-center gap-3 font-mono text-[28px] tracking-[0.2em] text-white md:mt-[100px] md:gap-4 md:text-[40px]">
         <span className="text-text-accent" aria-hidden="true">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/seo";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -6,5 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,9 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL, SITE_NAV_ITEMS } from "@/lib/seo";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return SITE_NAV_ITEMS.map((item) => ({
+    url: `${SITE_URL}${item.path}`,
+    lastModified: new Date(),
+  }));
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -17,6 +17,52 @@ type BuildMetadataOptions = {
   noIndex?: boolean;
 };
 
+// サイト内の主要ページ。ヘッダーナビと SiteNavigationElement JSON-LD で共有する
+export const SITE_NAV_ITEMS = [
+  { name: "Top", path: "/" },
+  { name: "Profile", path: "/profile" },
+];
+
+// 検索エンジンにサイト構造を伝える JSON-LD（サイトリンク表示の助けになる）
+export const siteNavigationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SiteNavigationElement",
+  name: SITE_NAV_ITEMS.map((item) => item.name),
+  url: SITE_NAV_ITEMS.map((item) => `${SITE_URL}${item.path}`),
+};
+
+// Person の knowsAbout に載せるスキル一覧（SkillTerminal の内容と揃える）
+export const PERSON_SKILLS = [
+  "UI/UX Design",
+  "Scrum Development",
+  "Data Analysis",
+  "Team Management",
+  "React",
+  "Next.js",
+  "TypeScript",
+  "Design System",
+  "Vue.js",
+  "Nuxt.js",
+  "GraphQL",
+];
+
+// サイト全体で使い回す Person 構造化データ(JSON-LD)
+export const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "稲葉勇人",
+  alternateName: "イナバくん",
+  jobTitle: "Front-end Engineer / Designer",
+  url: SITE_URL,
+  image: `${SITE_URL}/ogp.jpg`,
+  knowsAbout: PERSON_SKILLS,
+  sameAs: [
+    "https://twitter.com/dev_inabakun",
+    "https://github.com/inabakun178",
+    "https://www.instagram.com/purupuruboy2",
+  ],
+};
+
 export function buildMetadata({
   title,
   absoluteTitle,


### PR DESCRIPTION
## 概要

Google検索結果をリッチにするための対応。以下6点を実施。

## 変更内容

- sitemap.xml を追加（`/`・`/profile`）
- サイトアイコン設定（icons / manifest.json）を追加
- `SiteNavigationElement` の JSON-LD をレイアウトに追加
- profile ページに `BreadcrumbList` の JSON-LD を追加
- profile ページを `ProfilePage` schema でラップし、既存の Person JSON-LD を `mainEntity` に紐付け
- Person JSON-LD に `knowsAbout`（スキル一覧）を追加

## 確認方法

- `/sitemap.xml` にアクセスして `/` と `/profile` が含まれることを確認
- 各ページの `<script type="application/ld+json">` を確認（devtools or view-source）
- Google Rich Results Test で Person / BreadcrumbList / ProfilePage が検出されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01XFSHbbDWg7RVGiidZoBAFu)_