### PR TITLE
✨ ジャイロダイアログの表示中は演出を待たせ、背景を透過

### DIFF
--- a/src/components/effects/GyroPermissionDialog/GyroPermissionDialog.tsx
+++ b/src/components/effects/GyroPermissionDialog/GyroPermissionDialog.tsx
@@ -67,7 +67,7 @@ const GyroPermissionDialog = () => {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.3 }}
-          className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/40 px-6"
+          className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/20 px-6"
         >
           <motion.div
             initial={{ opacity: 0, scaleY: 0.85, y: 12 }}

--- a/src/components/effects/GyroPermissionDialog/GyroPermissionDialog.tsx
+++ b/src/components/effects/GyroPermissionDialog/GyroPermissionDialog.tsx
@@ -6,6 +6,7 @@ import {
   isGyroPermissionRequired,
   requestGyroPermission,
 } from "@/lib/gyroPermission";
+import { markIntroGateReady } from "@/lib/introGate";
 
 /**
  * サイト訪問時に最初に出す、端末の傾き(ジャイロ)センサーへのアクセス許可を求めるダイアログ。
@@ -26,6 +27,11 @@ const GyroPermissionDialog = () => {
   const allowButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
+    // ダイアログを最初から出さない端末(PCなど)では、背景演出をその場で開放する
+    if (!isOpen) markIntroGateReady();
+  }, [isOpen]);
+
+  useEffect(() => {
     if (!isOpen) return;
 
     const previousOverflow = document.body.style.overflow;
@@ -42,9 +48,13 @@ const GyroPermissionDialog = () => {
     await requestGyroPermission();
     setIsRequesting(false);
     setIsOpen(false);
+    markIntroGateReady();
   };
 
-  const handleSkip = () => setIsOpen(false);
+  const handleSkip = () => {
+    setIsOpen(false);
+    markIntroGateReady();
+  };
 
   return (
     <AnimatePresence>
@@ -57,7 +67,7 @@ const GyroPermissionDialog = () => {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.3 }}
-          className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/80 px-6 backdrop-blur-sm"
+          className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/40 px-6"
         >
           <motion.div
             initial={{ opacity: 0, scaleY: 0.85, y: 12 }}

--- a/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
+++ b/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
@@ -6,6 +6,7 @@ import {
   GYRO_PERMISSION_GRANTED_EVENT,
   isGyroPermissionRequired,
 } from "@/lib/gyroPermission";
+import { onIntroGateReady } from "@/lib/introGate";
 import { loadImage, sampleImageParticles } from "@/lib/particleSampler";
 import { fragment, lineFragment, vertex } from "./shaders";
 
@@ -95,6 +96,19 @@ const ParticleBackdrop = () => {
     let startTime = 0;
     let imageWidth = 1;
     let imageHeight = 1;
+    let isInitDone = false;
+    let isIntroReady = false;
+
+    // 画像サンプリングが終わっていて、かつジャイロ許可ダイアログが閉じている
+    // (出ない端末では最初から)場合にのみフェードインを開始する
+    const tryStart = () => {
+      if (!isInitDone || !isIntroReady || startTime) return;
+      startTime = performance.now() + START_DELAY * 1000;
+    };
+    const offIntroGateReady = onIntroGateReady(() => {
+      isIntroReady = true;
+      tryStart();
+    });
 
     const renderer = new Renderer({
       alpha: true,
@@ -316,7 +330,8 @@ const ParticleBackdrop = () => {
       }
 
       resize();
-      startTime = performance.now() + START_DELAY * 1000;
+      isInitDone = true;
+      tryStart();
     };
 
     const tick = (now: number) => {
@@ -364,6 +379,7 @@ const ParticleBackdrop = () => {
       window.removeEventListener("pointermove", handlePointerMove);
       window.removeEventListener(GYRO_PERMISSION_GRANTED_EVENT, enableGyro);
       window.removeEventListener("deviceorientation", handleOrientation);
+      offIntroGateReady();
       if (gl.canvas.parentElement === container) {
         container.removeChild(gl.canvas);
       }

--- a/src/components/layout/PageTemplate/PageTemplate.tsx
+++ b/src/components/layout/PageTemplate/PageTemplate.tsx
@@ -1,19 +1,31 @@
 "use client";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import HeaderNavigation from "../HeaderNavigation/HeaderNavigation";
 import SnsList from "../SnsList/SnsList";
 import ParticleBackdrop from "@/components/effects/ParticleBackdrop/ParticleBackdrop";
 import { motion } from "framer-motion";
+import { onIntroGateReady } from "@/lib/introGate";
 
 type PageTemplateProps = {
   children: ReactNode;
 };
 
 const PageTemplate = ({ children }: PageTemplateProps) => {
+  // ジャイロ許可ダイアログが閉じる(出ない端末では即座)までは、背景ズームを
+  // keyframesの開始状態(scale(1)・ぼかしあり)のまま止めておく
+  const [isBgReady, setIsBgReady] = useState(false);
+  useEffect(() => onIntroGateReady(() => setIsBgReady(true)), []);
+
   return (
     // before: は背景（public/site_bg.svg）をグレースケールで画面に固定するもの。
     // その上に同じ写真からサンプリングしたパーティクルを ParticleBackdrop で重ねる。
-    <div className="bg-background-main relative mx-auto min-h-dvh w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-dvh before:w-screen before:animate-bg-zoom before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:content-[''] md:px-[50px]">
+    <div
+      className={`bg-background-main relative mx-auto min-h-dvh w-full max-w-full px-[15px] before:fixed before:top-0 before:left-0 before:h-dvh before:w-screen before:bg-[url('/site_bg.svg')] before:bg-cover before:bg-center before:bg-no-repeat before:content-[''] md:px-[50px] ${
+        isBgReady
+          ? "before:animate-bg-zoom"
+          : "before:opacity-25 before:blur-[6px] before:grayscale"
+      }`}
+    >
       <ParticleBackdrop />
       <HeaderNavigation />
       <SnsList />

--- a/src/components/top/Fv/ParticlePortrait.tsx
+++ b/src/components/top/Fv/ParticlePortrait.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { Geometry, Mesh, Program, Renderer } from "ogl";
+import { onIntroGateReady } from "@/lib/introGate";
 import { loadImage, sampleImageParticles } from "@/lib/particleSampler";
 import { fragment, vertex } from "./shaders";
 
@@ -24,6 +25,19 @@ const ParticlePortrait = () => {
     let program: Program | null = null;
     let mesh: Mesh | null = null;
     let startTime = 0;
+    let isInitDone = false;
+    let isIntroReady = false;
+
+    // 一筆書きの描画開始を、パーティクル生成完了 かつ ジャイロ許可ダイアログが
+    // 閉じている(出ない端末では最初から)状態になるまで待つ
+    const tryStart = () => {
+      if (!isInitDone || !isIntroReady || startTime) return;
+      startTime = performance.now() + START_DELAY * 1000;
+    };
+    const offIntroGateReady = onIntroGateReady(() => {
+      isIntroReady = true;
+      tryStart();
+    });
 
     const renderer = new Renderer({
       alpha: true,
@@ -179,7 +193,8 @@ const ParticlePortrait = () => {
 
       mesh = new Mesh(gl, { mode: gl.POINTS, geometry, program });
       resize();
-      startTime = performance.now() + START_DELAY * 1000;
+      isInitDone = true;
+      tryStart();
     };
 
     const tick = (now: number) => {
@@ -212,6 +227,7 @@ const ParticlePortrait = () => {
       window.removeEventListener("resize", resize);
       container.removeEventListener("pointermove", handlePointerMove);
       container.removeEventListener("pointerleave", handlePointerLeave);
+      offIntroGateReady();
       if (gl.canvas.parentElement === container) {
         container.removeChild(gl.canvas);
       }

--- a/src/lib/introGate.ts
+++ b/src/lib/introGate.ts
@@ -1,0 +1,30 @@
+// ジャイロ許可ダイアログが閉じる(または最初から出ない)まで、背景演出の開始を
+// 待たせるためのゲート。ダイアログの裏で粒子アニメーションや背景ズームが
+// 先走って始まってしまうのを防ぐ。
+
+export const INTRO_GATE_READY_EVENT = "intro-gate-ready";
+
+declare global {
+  interface Window {
+    __introGateReady?: boolean;
+  }
+}
+
+export const isIntroGateReady = () =>
+  typeof window !== "undefined" && window.__introGateReady === true;
+
+export const markIntroGateReady = () => {
+  if (typeof window === "undefined" || window.__introGateReady) return;
+  window.__introGateReady = true;
+  window.dispatchEvent(new Event(INTRO_GATE_READY_EVENT));
+};
+
+/** 既に開放済みなら即座にcallbackを呼ぶ。未開放ならイベントを待つ。 */
+export const onIntroGateReady = (callback: () => void): (() => void) => {
+  if (isIntroGateReady()) {
+    callback();
+    return () => {};
+  }
+  window.addEventListener(INTRO_GATE_READY_EVENT, callback);
+  return () => window.removeEventListener(INTRO_GATE_READY_EVENT, callback);
+};


### PR DESCRIPTION
## 概要

- ジャイロ許可ダイアログが最初に出るサイトで、粒子背景や背景ズームのアニメーションがダイアログの裏で先に始まってしまっていたのを修正
- ダイアログの背景の不透明度を下げ、開いている間も後ろのサイトが見えるようにした

## 変更内容

- `src/lib/introGate.ts` を追加。ダイアログが閉じる(許可/skip、またはそもそも出ない端末では即座)まで背景演出の開始を待たせるゲートを実装
- `GyroPermissionDialog`: ダイアログの決着タイミングで `markIntroGateReady()` を呼ぶように変更。背景オーバーレイを `bg-black/80` + `backdrop-blur-sm` から `bg-black/40`（ぼかしなし）に変更し、後ろのサイトが見えるように
- `ParticleBackdrop`: 粒子のフェードイン開始を、画像サンプリング完了 かつ ゲート開放後まで待つように変更
- `PageTemplate`: 背景ズームCSSアニメーション(`animate-bg-zoom`)の付与を、ゲート開放後まで遅らせるように変更(それまではキーフレームの開始状態と同じ見た目で静止)

## 確認方法

- PCブラウザ(ポインターが coarse でない環境): ダイアログは出ないため、ページ読み込み直後から背景ズーム・粒子アニメーションが始まることを確認
- スマホ実機 or DevToolsのタッチエミュレーション: ダイアログが表示され、背景が薄く透けて後ろのサイトが見えることを確認。`allow`/`skip` を押してダイアログが閉じたあとに、背景ズームと粒子アニメーションが始まることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01FsZRE9ZDmRfrJo2fXRU8gm)_