### PR TITLE
✨ プロフィールページのターミナル演出もダイアログ待ちに

### DIFF
--- a/src/components/profile/TerminalWindow/TerminalWindow.tsx
+++ b/src/components/profile/TerminalWindow/TerminalWindow.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { motion } from "framer-motion";
+import { useIntroGateReady } from "@/lib/introGate";
 
 type TerminalWindowProps = {
   title: string;
@@ -15,11 +16,17 @@ type TerminalWindowProps = {
 // profile ページ専用のターミナル風ウィンドウ。配色は global.css の --color-cyber-* トークンから取る
 const TerminalWindow = (props: TerminalWindowProps) => {
   const bootDelay = props.bootDelay ?? 0;
+  // ジャイロ許可ダイアログが閉じる(出ない端末では最初から)まで、起動アニメーションを待たせる
+  const isIntroReady = useIntroGateReady();
 
   return (
     <motion.div
       initial={{ opacity: 0, scaleY: 0.85, y: 12 }}
-      animate={{ opacity: 1, scaleY: 1, y: 0 }}
+      animate={
+        isIntroReady
+          ? { opacity: 1, scaleY: 1, y: 0 }
+          : { opacity: 0, scaleY: 0.85, y: 12 }
+      }
       transition={{ duration: 1, delay: bootDelay, ease: "easeOut" }}
       style={{ transformOrigin: "top" }}
       className="border-text-accent/40 relative overflow-hidden rounded-md border bg-[rgba(1,1,1,0.8)] font-mono md:bg-cyber-bg"

--- a/src/components/profile/TerminalWindow/useTypewriter.ts
+++ b/src/components/profile/TerminalWindow/useTypewriter.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { onIntroGateReady } from "@/lib/introGate";
 
 export type TerminalSegment = {
   text: string;
@@ -64,11 +65,16 @@ export const useTypewriter = (
       setProgress((prev) => ({ ...prev, finished: true }));
     };
 
-    timeoutId = setTimeout(() => tick(0, 0), startDelay);
+    // ジャイロ許可ダイアログが閉じる(出ない端末では最初から)まで、
+    // タイプライターの開始を待たせる
+    const offIntroGateReady = onIntroGateReady(() => {
+      timeoutId = setTimeout(() => tick(0, 0), startDelay);
+    });
 
     return () => {
       cancelled = true;
       clearTimeout(timeoutId);
+      offIntroGateReady();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [speed, startDelay]);

--- a/src/lib/introGate.ts
+++ b/src/lib/introGate.ts
@@ -2,6 +2,8 @@
 // 待たせるためのゲート。ダイアログの裏で粒子アニメーションや背景ズームが
 // 先走って始まってしまうのを防ぐ。
 
+import { useEffect, useState } from "react";
+
 export const INTRO_GATE_READY_EVENT = "intro-gate-ready";
 
 declare global {
@@ -27,4 +29,11 @@ export const onIntroGateReady = (callback: () => void): (() => void) => {
   }
   window.addEventListener(INTRO_GATE_READY_EVENT, callback);
   return () => window.removeEventListener(INTRO_GATE_READY_EVENT, callback);
+};
+
+/** DOM/CSSアニメーション向け。ゲートが開くまでfalseを返し、開いたらtrueに切り替わる。 */
+export const useIntroGateReady = () => {
+  const [isReady, setIsReady] = useState(isIntroGateReady);
+  useEffect(() => onIntroGateReady(() => setIsReady(true)), []);
+  return isReady;
 };


### PR DESCRIPTION
## 概要

- プロフィールページのターミナル風UI(ProfileTerminal / CareerTerminal / SkillTerminal)の起動アニメーションとタイプライター演出が、ジャイロ許可ダイアログの裏で先走って始まっていたのを修正
- #224 で導入した `introGate` に乗せて、ダイアログが決着する(許可/skip、または最初から出ない端末では即座)まで待たせるようにした

## 変更内容

- `src/lib/introGate.ts`: DOM/CSSアニメーション向けの `useIntroGateReady` フックを追加
- `TerminalWindow`: 起動時のフェードイン・スケールアニメーションを `useIntroGateReady` で待たせるように変更
- `useTypewriter`: タイプライターの文字送り開始を、ゲートが開くまで待たせるように変更

## 確認方法

- スマホ実機 or DevToolsのタッチエミュレーションでプロフィールページを開く
- ジャイロ許可ダイアログが表示されている間、ターミナルの枠や文字送りが始まっていないことを確認
- `allow`/`skip` を押してダイアログが閉じたあとに、ターミナルの起動アニメーションとタイプライターが順に始まることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01FsZRE9ZDmRfrJo2fXRU8gm)_