### PR TITLE
⚡️ 動作確認用にタイプライター速度を一時的に10倍に変更

### DIFF
--- a/src/components/profile/TerminalWindow/useTypewriter.ts
+++ b/src/components/profile/TerminalWindow/useTypewriter.ts
@@ -27,7 +27,7 @@ export const useTypewriter = (
   lines: TerminalLine[],
   options?: { speed?: number; startDelay?: number; active?: boolean },
 ) => {
-  const speed = options?.speed ?? 10 / 2;
+  const speed = options?.speed ?? 10 / 10;
   const startDelay = options?.startDelay ?? 0;
   // スクロールで画面内に入るまで開始を待たせたいときに false で渡す
   const active = options?.active ?? true;


### PR DESCRIPTION
## 概要

タイプライター速度を変えても体感で変化がないという報告があり、原因切り分けのため一時的に10倍速(1ms/文字)にして確認する。

## 変更内容

- `useTypewriter` のデフォルト速度を `10/2ms` から `10/10ms` に変更

## 確認方法

- プロフィールページの各ターミナルで、文字がほぼ一瞬で表示されるレベルまで速くなっているかを確認する


---
_Generated by [Claude Code](https://claude.ai/code/session_0152Mys7oo5ZNraxbXW8RVa5)_