### PR TITLE
💄 背景の粒子と線をグレーから白に戻す

### DIFF
--- a/src/components/effects/ParticleBackdrop/shaders.ts
+++ b/src/components/effects/ParticleBackdrop/shaders.ts
@@ -80,9 +80,7 @@ export const fragment = /* glsl */ `
     // 0.6倍に抑えて透過させる(周辺の散らばり粒子(vShape=0)は変更しない)
     alpha *= mix(1.0, 0.6, vShape);
 
-    // FVロゴ(オレンジ〜レッド)と色が競合して視認性が下がらないよう、
-    // 背景粒子はグレーに統一する
-    vec3 color = vec3(0.35, 0.35, 0.35);
+    vec3 color = vec3(1.0, 1.0, 1.0);
 
     gl_FragColor = vec4(color, alpha);
   }
@@ -96,9 +94,9 @@ export const lineFragment = /* glsl */ `
   varying float vAlpha;
 
   void main() {
-    vec3 gray = vec3(0.4, 0.4, 0.4);
+    vec3 white = vec3(1.0, 1.0, 1.0);
     // 線が濃く見えすぎていたため、0.3倍に抑えて透過させる
     float alpha = (0.6 + vBrightness * 0.4) * vAlpha * 0.3;
-    gl_FragColor = vec4(gray, alpha);
+    gl_FragColor = vec4(white, alpha);
   }
 `;


### PR DESCRIPTION
## 概要

背景の粒子と線がグレーになっていたのを白に戻す。

## 変更内容

- `src/components/effects/ParticleBackdrop/shaders.ts` の粒子色・線色を白(1.0, 1.0, 1.0)に変更
- 透過度(alpha)のロジックは変更なし

## 確認方法

- トップページの背景演出(粒子・線)が白で表示されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUo4BMXovwp1GdeQ9EdjsC)_