### PR TITLE
トップページに視覚上非表示のh1を追加してSEO強化

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,11 @@ export const metadata: Metadata = buildMetadata({
 export default function Home() {
   return (
     <PageTemplate>
+      {/* ファーストビューはcanvas演出のみで本文テキストが無いため、SEO用にh1を視覚上は隠して補う */}
+      <h1 className="sr-only">
+        稲葉勇人（イナバくん） / Have Your Inabakun -
+        フロントエンドエンジニア・デザイナーのポートフォリオサイト
+      </h1>
       <Fv />
       {/* TODO: scroll button置く */}
       {/* TODO: 実績リスト置く */}


### PR DESCRIPTION
## Summary
- トップページ（`/`）がcanvas演出のみでh1・本文テキストが無く、「稲葉勇人」「イナバくん」がメタデータ内にしか存在しなかった
- `sr-only` の `<h1>` を追加し、クロール対象のテキストとしてキーワードを補完

## Test plan
- [x] `pnpm run tsc`
- [x] `pnpm run lint:check`
- [x] `pnpm run format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TRH4CU5nm3f4Lr9ZcdCCrd)_