### PR TITLE
💄 PCのFV背景の粒子+線のopacityを濃くする

### DIFF
--- a/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
+++ b/src/components/effects/ParticleBackdrop/ParticleBackdrop.tsx
@@ -148,6 +148,8 @@ const ParticleBackdrop = () => {
     // スマホ(タッチ主体の端末)ではマウス座標の代わりに端末の傾き(ジャイロ)で
     // パララックスを動かす
     const isCoarsePointer = window.matchMedia?.("(pointer: coarse)").matches;
+    // PCではスマホより粒子+線が薄く見えるため、PC限定で不透明度を底上げする
+    const opacityBoost = isCoarsePointer ? 0 : 0.2;
 
     const handlePointerMove = (event: PointerEvent) => {
       if (isCoarsePointer) return;
@@ -260,6 +262,7 @@ const ParticleBackdrop = () => {
           uParallax: { value: [0, 0] },
           uPointSize: { value: 2.7 },
           uDpr: { value: renderer.dpr },
+          uOpacityBoost: { value: opacityBoost },
         },
       });
 
@@ -319,6 +322,7 @@ const ParticleBackdrop = () => {
             uParallax: { value: [0, 0] },
             uPointSize: { value: 1 },
             uDpr: { value: renderer.dpr },
+            uOpacityBoost: { value: opacityBoost },
           },
         });
 

--- a/src/components/effects/ParticleBackdrop/shaders.ts
+++ b/src/components/effects/ParticleBackdrop/shaders.ts
@@ -62,6 +62,8 @@ export const vertex = /* glsl */ `
 export const fragment = /* glsl */ `
   precision highp float;
 
+  uniform float uOpacityBoost;
+
   varying float vBrightness;
   varying float vAlpha;
   varying float vShape;
@@ -79,6 +81,8 @@ export const fragment = /* glsl */ `
     // 輪郭粒子(vShape=1)がほぼ不透明に見えていたため、PC/スマホ問わず
     // 0.6倍に抑えて透過させる(周辺の散らばり粒子(vShape=0)は変更しない)
     alpha *= mix(1.0, 0.6, vShape);
+    // PCでは薄く見えづらいため、uOpacityBoost(PC限定で加算)で濃くする
+    alpha = clamp(alpha + uOpacityBoost, 0.0, 1.0);
 
     vec3 color = vec3(1.0, 1.0, 1.0);
 
@@ -90,6 +94,8 @@ export const fragment = /* glsl */ `
 export const lineFragment = /* glsl */ `
   precision highp float;
 
+  uniform float uOpacityBoost;
+
   varying float vBrightness;
   varying float vAlpha;
 
@@ -97,6 +103,8 @@ export const lineFragment = /* glsl */ `
     vec3 white = vec3(1.0, 1.0, 1.0);
     // 線が濃く見えすぎていたため、0.3倍に抑えて透過させる
     float alpha = (0.6 + vBrightness * 0.4) * vAlpha * 0.3;
+    // PCでは薄く見えづらいため、uOpacityBoost(PC限定で加算)で濃くする
+    alpha = clamp(alpha + uOpacityBoost, 0.0, 1.0);
     gl_FragColor = vec4(white, alpha);
   }
 `;


### PR DESCRIPTION
## 概要

PC版でFVの背景の粒子+線のopacityが薄く見えていたため、PC限定でopacityを0.2濃くする。

## 変更内容

- `ParticleBackdrop.tsx`: `pointer: coarse`でない(=PC)環境を判定し、`uOpacityBoost`を0.2に設定(スマホ相当の環境では0のまま変更なし)
- `shaders.ts`: 粒子用フラグメントシェーダー・線用フラグメントシェーダーの双方に`uOpacityBoost`uniformを追加し、最終alphaに加算(0〜1にクランプ)

## 確認方法

- PCブラウザでトップページのFVを開き、背景の粒子・線が従来より濃く見えることを確認
- スマホ(またはブラウザのdevtoolsでタッチデバイスをエミュレート)では見た目が変わっていないことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01RFns1HZVxk5KkdJvqJEQmj)_